### PR TITLE
Release-PRを自動作成するCIを追加

### DIFF
--- a/.github/RELEASE_PULL_REQUEST_TEMPLATE.md
+++ b/.github/RELEASE_PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+<%= ENV['PR_TITLE'] %>
+
+## 確認事項
+- [ ] staging での動作チェック
+
+## 更新内容
+<% pull_requests.each do |pr| -%>
+<%= pr.to_checklist_item %>
+<% end -%>

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,62 @@
+name: Deploy and Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Deploy to Cloudflare Workers
+        run: pnpm exec wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  release:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set release tag
+        env:
+          TZ: "Asia/Tokyo"
+        run: |
+          echo "RELEASE_TAG=$(date '+%Y-%m-%d-%H%M%S')" >> $GITHUB_ENV
+          echo "RELEASE_NAME=$(date '+%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: ${{ env.RELEASE_NAME }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+name: Create Release Pull Request
+
+on:
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up environment variables
+        env:
+          TZ: "Asia/Tokyo"
+        run: |
+          echo "PR_TITLE=Release $(date '+%Y-%m-%d %H:%M:%S') +09:00" >> $GITHUB_ENV
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4.9"
+          bundler-cache: true
+
+      - name: Install git-pr-release
+        run: gem install --no-document git-pr-release
+
+      - name: Create a release pull request
+        run: git-pr-release --squashed
+        env:
+          GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_PR_RELEASE_BRANCH_PRODUCTION: main
+          GIT_PR_RELEASE_BRANCH_STAGING: staging
+          GIT_PR_RELEASE_LABELS: release production
+          GIT_PR_RELEASE_TEMPLATE: .github/RELEASE_PULL_REQUEST_TEMPLATE.md

--- a/.github/workflows/staging-preview.yml
+++ b/.github/workflows/staging-preview.yml
@@ -1,0 +1,40 @@
+name: Staging Preview
+
+on:
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Deploy to Cloudflare Workers (staging)
+        run: pnpm exec wrangler deploy --config wrangler.staging.jsonc
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,27 @@ pnpm run dev
 
 ## 本番環境へのデプロイ
 
-### シークレットの設定
+[mimifuwa.cc](https://github.com/mimifuwacc/mimifuwa.cc) と同様に、`staging` で開発してリリース PR 経由で `main` に入れたときだけ本番デプロイします。
+
+### リリースの流れ
+
+1. 機能ブランチを `staging` にマージする
+   - **Staging Preview** … staging 環境へデプロイ
+   - **Create Release Pull Request** … `staging` → `main` のリリース PR を自動作成・更新
+2. リリース PR で変更内容を確認し、`staging` での動作チェックを済ませる
+3. リリース PR を `main` にマージする
+   - **Deploy and Release** … 本番デプロイ + タイムスタンプ付き GitHub Release 作成
+
+### 初回セットアップ（リポジトリ管理者向け）
+
+1. Cloudflare Dashboard の Workers Builds で **Git リポジトリの接続を Disconnect** する
+2. GitHub リポジトリの Secrets に以下を登録する
+   - `CLOUDFLARE_API_TOKEN`
+   - `CLOUDFLARE_ACCOUNT_ID`
+3. `staging` ブランチを作成し、以降の開発は `staging` 向けに行う
+4. `wrangler.staging.jsonc` の D1 / KV ID を staging 用リソースの値に差し替える
+
+### Wrangler シークレットの設定
 
 ```bash
 # GitHub OAuth
@@ -67,11 +87,13 @@ wrangler secret put SESSION_SECRET
 wrangler secret put RAKUTEN_APP_ID
 ```
 
-### デプロイ
+### 手動デプロイ（緊急時のみ）
 
 ```bash
 pnpm run deploy
 ```
+
+または GitHub Actions の **Deploy and Release** workflow を `workflow_dispatch` で手動実行します。
 
 ## ちょくちょく使う開発コマンド
 

--- a/wrangler.staging.jsonc
+++ b/wrangler.staging.jsonc
@@ -1,0 +1,28 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "gidoku-com-staging",
+  "main": "./dist/index.js",
+  "compatibility_date": "2025-12-09",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "directory": "./dist"
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "gidoku-db-staging",
+      "database_id": "REPLACE_WITH_STAGING_D1_DATABASE_ID"
+    }
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "KV",
+      "id": "REPLACE_WITH_STAGING_KV_NAMESPACE_ID"
+    }
+  ],
+  "vars": {
+    "GITHUB_CLIENT_ID": "Ov23li1W8sYXe7C1fWlR",
+    "GOOGLE_CLIENT_ID": "494336925174-ovnmt0b3ssdfqfvgtm1n28va40oau4n1.apps.googleusercontent.com",
+    "APP_URL": "https://gidoku-com-staging.workers.dev"
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue #76 向けに、mimifuwa.cc と同様のリリースフローを追加します。

## フロー

```mermaid
flowchart LR
  A[feature] -->|PR| B[staging]
  B -->|Staging Preview| C[プレビュー環境]
  B -->|git-pr-release| D[staging → main リリース PR]
  D -->|マージ| E[main]
  E -->|Deploy and Release| F[本番 gidoku.com]
```

1. **機能 PR → `staging`**: プレビューデプロイ + リリース PR 自動作成
2. **リリース PR をマージ → `main`**: 本番デプロイ + タイムスタンプ付き GitHub Release

## 変更内容

- `.github/workflows/release.yaml` — `git-pr-release` でリリース PR 作成
- `.github/workflows/staging-preview.yml` — staging へのプレビューデプロイ
- `.github/workflows/deploy.yml` — main への本番デプロイ + Release 作成
- `.github/RELEASE_PULL_REQUEST_TEMPLATE.md` — リリース PR テンプレート
- `wrangler.staging.jsonc` — staging 用 Worker 設定

## マージ後に必要な作業（手動）

1. Cloudflare Dashboard で Git リポジトリの接続を **Disconnect**
2. GitHub Secrets に `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` を登録
3. `staging` ブランチを作成（デフォルトブランチにするのも推奨）
4. `wrangler.staging.jsonc` の D1 / KV ID を設定

Closes #76
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab4335db-09e6-499f-bec3-7568c246aff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab4335db-09e6-499f-bec3-7568c246aff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

