### PR TITLE
fix: staging にリリース対象がないとき release workflow を落とさない

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,19 @@ jobs:
         run: gem install --no-document git-pr-release
 
       - name: Create a release pull request
-        run: git-pr-release --squashed
+        run: |
+          set +e
+          output=$(git-pr-release --squashed 2>&1)
+          exit_code=$?
+          echo "$output"
+          if [ $exit_code -eq 0 ]; then
+            exit 0
+          fi
+          if echo "$output" | grep -q "No pull requests to be released"; then
+            echo "No merged PRs to release yet. Skipping."
+            exit 0
+          fi
+          exit $exit_code
         env:
           GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_PR_RELEASE_BRANCH_PRODUCTION: main


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

`staging` ブランチ作成直後など、まだ `staging` にマージされた PR がない場合に `git-pr-release` が exit 1 で落ちる問題を修正します。

## 変更内容

- `No pull requests to be released` のときは workflow を成功扱いでスキップ

Closes #76
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab4335db-09e6-499f-bec3-7568c246aff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab4335db-09e6-499f-bec3-7568c246aff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

