### PR TITLE
chore: staging 用 OAuth と staging.gidoku.com を設定

### DIFF
--- a/wrangler.staging.jsonc
+++ b/wrangler.staging.jsonc
@@ -23,8 +23,14 @@
 		}
 	],
 	"vars": {
-		"GITHUB_CLIENT_ID": "Ov23li1W8sYXe7C1fWlR",
-		"GOOGLE_CLIENT_ID": "494336925174-ovnmt0b3ssdfqfvgtm1n28va40oau4n1.apps.googleusercontent.com",
-		"APP_URL": "https://gidoku-com-staging.workers.dev"
-	}
+		"GITHUB_CLIENT_ID": "Ov23liq4okvsI8w6kVsC",
+		"GOOGLE_CLIENT_ID": "494336925174-q3f41lih9r2o58unehpr312oncl3mdft.apps.googleusercontent.com",
+		"APP_URL": "https://staging.gidoku.com"
+	},
+	"routes": [
+		{
+			"pattern": "staging.gidoku.com",
+			"custom_domain": true
+		}
+	]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

staging 環境用の OAuth Client ID とカスタムドメインを `wrangler.staging.jsonc` に反映します。

## 変更内容

- `GITHUB_CLIENT_ID` → staging 用 OAuth アプリ
- `GOOGLE_CLIENT_ID` → staging 用 OAuth クライアント
- `APP_URL` → `https://staging.gidoku.com`
- `staging.gidoku.com` のカスタムドメイン route を追加

## マージ後に必要な作業（手動）

シークレットはリポジトリに含めないため、マージ後に staging Worker へ設定してください。

```bash
wrangler secret put GITHUB_CLIENT_SECRET --config wrangler.staging.jsonc
wrangler secret put GOOGLE_CLIENT_SECRET --config wrangler.staging.jsonc
```

OAuth アプリ側のコールバック URL:

- `https://staging.gidoku.com/api/auth/github/callback`
- `https://staging.gidoku.com/api/auth/google/callback`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab4335db-09e6-499f-bec3-7568c246aff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab4335db-09e6-499f-bec3-7568c246aff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

