### PR TITLE
fix: 書籍詳細の削除ボタンのスタイルを修正

### DIFF
--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -1,24 +1,40 @@
 import type { FC, PropsWithChildren, CSSProperties } from "hono/jsx";
 
-type ButtonVariant = "primary" | "secondary" | "danger" | "ghost";
+type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "danger"
+  | "danger-soft"
+  | "ghost";
 type ButtonSize = "sm" | "md" | "lg";
+type ButtonShape = "md" | "pill" | "xl";
+type ButtonWeight = "medium" | "bold";
 
 interface ButtonProps {
   type?: "button" | "submit" | "reset";
   variant?: ButtonVariant;
   size?: ButtonSize;
+  shape?: ButtonShape;
+  weight?: ButtonWeight;
   disabled?: boolean;
   class?: string;
   style?: CSSProperties;
   onClick?: string;
 }
 
+const baseStyles =
+  "inline-flex items-center justify-center transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed";
+
 const variantStyles: Record<ButtonVariant, string> = {
-  primary: "bg-zinc-900 text-white hover:bg-zinc-800 shadow-sm",
+  primary: "bg-zinc-900 text-white hover:bg-zinc-800 shadow-sm focus:ring-zinc-900",
   secondary:
-    "bg-white text-zinc-900 border border-zinc-200 hover:bg-zinc-50 shadow-sm",
-  danger: "bg-red-600 text-white hover:bg-red-700 shadow-sm",
-  ghost: "bg-transparent text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900",
+    "bg-white text-zinc-900 border border-zinc-200 hover:bg-zinc-50 shadow-sm focus:ring-zinc-900",
+  danger:
+    "bg-white text-red-600 border border-red-100 hover:bg-red-50 hover:text-red-700 shadow-sm focus:ring-red-500",
+  "danger-soft":
+    "bg-red-50 text-red-600 border border-red-100 hover:bg-red-100 shadow-sm focus:ring-red-500",
+  ghost:
+    "bg-transparent text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 focus:ring-zinc-900",
 };
 
 const sizeStyles: Record<ButtonSize, string> = {
@@ -27,11 +43,24 @@ const sizeStyles: Record<ButtonSize, string> = {
   lg: "px-6 py-3 text-base",
 };
 
+const shapeStyles: Record<ButtonShape, string> = {
+  md: "rounded-lg",
+  pill: "rounded-full",
+  xl: "rounded-xl",
+};
+
+const weightStyles: Record<ButtonWeight, string> = {
+  medium: "font-medium",
+  bold: "font-bold",
+};
+
 export const Button: FC<PropsWithChildren<ButtonProps>> = ({
   children,
   type = "button",
   variant = "primary",
   size = "md",
+  shape = "md",
+  weight = "medium",
   disabled = false,
   class: className = "",
   style,
@@ -42,7 +71,7 @@ export const Button: FC<PropsWithChildren<ButtonProps>> = ({
       type={type}
       disabled={disabled}
       onclick={onClick}
-      class={`inline-flex items-center justify-center rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
+      class={`${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${shapeStyles[shape]} ${weightStyles[weight]} ${className}`}
       style={style}
     >
       {children}

--- a/app/routes/books/[id]/edit.tsx
+++ b/app/routes/books/[id]/edit.tsx
@@ -131,7 +131,9 @@ export default createRoute(async (c) => {
             </a>
             <Button
               type="button"
-              class="rounded-full px-8 py-2.5 font-bold shadow-sm"
+              shape="pill"
+              weight="bold"
+              class="px-8 py-2.5"
               onClick={`
                 const form = document.getElementById('edit-form');
                 const btn = this;

--- a/app/routes/books/[id]/index.tsx
+++ b/app/routes/books/[id]/index.tsx
@@ -3,7 +3,6 @@ import { requirePageAuth, getSidebarExpanded } from "../../../lib/page-auth";
 import { Layout } from "../../../components/layout/Layout";
 import { StatusBadge, Badge } from "../../../components/ui/Badge";
 import { BookCover } from "../../../components/book/BookCover";
-import { Button } from "../../../components/ui/Button";
 import { bookRepo, bookTagRepo } from "../../../server/db/repositories";
 import ProgressSlider from "../../../islands/ProgressSlider";
 import StatusToggle from "../../../islands/StatusToggle";
@@ -60,14 +59,13 @@ export default createRoute(async (c) => {
             >
               編集
             </a>
-            <Button
-              variant="danger"
-              size="sm"
-              class="bg-white text-red-600 hover:bg-red-50 border border-red-100 font-bold rounded-full shadow-sm"
-              onClick={`if(confirm('この本を削除しますか？')) { fetch('/api/books/${book.id}', { method: 'DELETE' }).then(() => location.href = '/books') }`}
+            <button
+              type="button"
+              class="text-sm font-bold text-red-600 hover:text-red-700 transition-colors px-4 py-2 bg-white rounded-full border border-red-100 hover:bg-red-50 shadow-sm"
+              onclick={`if(confirm('この本を削除しますか？')) { fetch('/api/books/${book.id}', { method: 'DELETE' }).then(() => location.href = '/books') }`}
             >
               削除
-            </Button>
+            </button>
           </div>
         </div>
 

--- a/app/routes/books/[id]/index.tsx
+++ b/app/routes/books/[id]/index.tsx
@@ -3,6 +3,7 @@ import { requirePageAuth, getSidebarExpanded } from "../../../lib/page-auth";
 import { Layout } from "../../../components/layout/Layout";
 import { StatusBadge, Badge } from "../../../components/ui/Badge";
 import { BookCover } from "../../../components/book/BookCover";
+import { Button } from "../../../components/ui/Button";
 import { bookRepo, bookTagRepo } from "../../../server/db/repositories";
 import ProgressSlider from "../../../islands/ProgressSlider";
 import StatusToggle from "../../../islands/StatusToggle";
@@ -59,13 +60,14 @@ export default createRoute(async (c) => {
             >
               編集
             </a>
-            <button
-              type="button"
-              class="text-sm font-bold text-red-600 hover:text-red-700 transition-colors px-4 py-2 bg-white rounded-full border border-red-100 hover:bg-red-50 shadow-sm"
-              onclick={`if(confirm('この本を削除しますか？')) { fetch('/api/books/${book.id}', { method: 'DELETE' }).then(() => location.href = '/books') }`}
+            <Button
+              variant="danger"
+              shape="pill"
+              weight="bold"
+              onClick={`if(confirm('この本を削除しますか？')) { fetch('/api/books/${book.id}', { method: 'DELETE' }).then(() => location.href = '/books') }`}
             >
               削除
-            </button>
+            </Button>
           </div>
         </div>
 

--- a/app/routes/books/index.tsx
+++ b/app/routes/books/index.tsx
@@ -103,7 +103,7 @@ export default createRoute(async (c) => {
             />
           </div>
 
-          <Button type="submit" class="sm:w-auto w-full font-bold py-2.5 rounded-xl">
+          <Button type="submit" shape="xl" weight="bold" class="sm:w-auto w-full py-2.5">
             検索
           </Button>
         </form>

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -110,8 +110,10 @@ export default createRoute(async (c) => {
             <div class="pt-6 border-t border-zinc-50">
               <Button
                 type="button"
-                variant="danger"
-                class="bg-red-50 text-red-600 hover:bg-red-100 shadow-none border border-red-100 rounded-full px-6 font-bold"
+                variant="danger-soft"
+                shape="pill"
+                weight="bold"
+                class="px-6"
                 onClick={`
                   if (confirm('ログアウトしますか？')) {
                     fetch('/api/auth/logout', {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Fixes #31

書籍詳細ページの削除ボタンのスタイルが意図通りに表示されない問題を修正しました。レビュー指摘を受け、生の `button` 要素ではなく `Button` atom を汎用化して対応しています。

## 原因

削除ボタンは `Button` の `variant="danger"`（赤背景）を使いつつ、`class` で白背景のアウトラインスタイルを上書きしようとしていました。Tailwind CSS では HTML 上のクラス順ではなく生成された CSS の順序で優先度が決まるため、意図したスタイルが適用されませんでした。

## 修正内容

- `Button` を atom として再設計し、以下を props で制御できるようにした
  - `variant`: `primary` / `secondary` / `danger` / `danger-soft` / `ghost`
  - `shape`: `md` / `pill` / `xl`
  - `weight`: `medium` / `bold`
- 書籍詳細の削除ボタンは `variant="danger"` + `shape="pill"` + `weight="bold"` で表現
- 設定ページのログアウトボタンは `variant="danger-soft"` に移行し、クラス上書きを削除
- 既存の `Button` 利用箇所（書籍編集・検索）も新 props に合わせて整理

## テスト

- `pnpm run typecheck` ✅
- `pnpm test` ✅ (162 passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-892f69c4-e4a2-46c9-8ea3-35dc264b77b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-892f69c4-e4a2-46c9-8ea3-35dc264b77b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

