### PR TITLE
fix: 読書ステータスUIを中央揃えに統一

### DIFF
--- a/app/islands/BooksStatusTabs.tsx
+++ b/app/islands/BooksStatusTabs.tsx
@@ -61,7 +61,7 @@ export default function BooksStatusTabs({
 
   return (
     <div class="space-y-6">
-      <div class="flex flex-col items-center sm:flex-row sm:items-center sm:justify-between gap-4">
+      <div class="flex flex-col items-center gap-4">
         <p class="text-zinc-500 font-medium">全 {total} 冊</p>
         <div
           class="inline-flex items-center gap-1 rounded-full bg-zinc-100 p-1"

--- a/app/islands/ProfileBookTabs.tsx
+++ b/app/islands/ProfileBookTabs.tsx
@@ -53,7 +53,7 @@ export default function ProfileBookTabs({
 
   return (
     <div class="space-y-6">
-      <div class="flex items-center justify-between gap-4">
+      <div class="flex flex-col items-center gap-4">
         <h2 class="text-xl font-bold text-zinc-900">本の一覧</h2>
         <div
           class="inline-flex items-center gap-1 rounded-full bg-zinc-100 p-1"

--- a/app/islands/StatusToggle.tsx
+++ b/app/islands/StatusToggle.tsx
@@ -51,7 +51,8 @@ export default function StatusToggle({
   };
 
   return (
-    <div class="items-center inline-flex gap-1 p-1 bg-zinc-100 rounded-lg">
+    <div class="flex w-full justify-center">
+      <div class="inline-flex items-center gap-1 p-1 bg-zinc-100 rounded-lg">
       {statusOptions.map((option) => (
         <button
           key={option.value}
@@ -66,6 +67,7 @@ export default function StatusToggle({
           {option.label}
         </button>
       ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

読書ステータス関連のUIを、PC・スマホ問わず中央揃えに統一しました。

## 変更内容

- **書籍詳細 (`StatusToggle`)**: `inline-flex` の左寄せを解消し、`flex w-full justify-center` で中央配置
- **本棚ページ (`BooksStatusTabs`)**: PC版の `justify-between`（左右配置）を廃止し、スマホ同様の縦並び・中央揃えに統一
- **公開プロフィール (`ProfileBookTabs`)**: タイトルとステータスタブを縦並び・中央揃えに統一

## 背景

ステータス切り替えUIが画面・ページごとに左寄せ・右寄せ・中央寄せとバラバラだったため、見た目と操作感を揃える目的で統一しています。

## テスト

- `pnpm test` — 全162件パス
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc829666-8080-49e9-8053-202dbcd5c954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc829666-8080-49e9-8053-202dbcd5c954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

