### PR TITLE
OxlintとOxfmt入れよう

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,76 @@
-name: Test
+name: CI
 
 on:
   push:
   pull_request:
 
 jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm run typecheck
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run lint
+        run: pnpm run lint
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting
+        run: pnpm run format:check
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -18,14 +84,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'pnpm'
+          node-version: "22"
+          cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
-
-      - name: Type check
-        run: pnpm typecheck
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm run test

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "ignorePatterns": [
+    "node_modules/**",
+    "dist/**",
+    ".wrangler/**",
+    ".codex/**",
+    ".claude/**",
+    "worker-configuration.d.ts",
+    "pnpm-lock.yaml",
+    "*.md",
+    "public/icons/**"
+  ]
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "perf": "warn",
+    "style": "off",
+    "pedantic": "off",
+    "nursery": "off"
+  },
+  "ignorePatterns": ["node_modules/**", "dist/**", ".wrangler/**", "worker-configuration.d.ts"]
+}

--- a/app/components/book/BookCard.tsx
+++ b/app/components/book/BookCard.tsx
@@ -33,20 +33,12 @@ export const BookCard: FC<BookCardProps> = ({
         <BookCover src={thumbnailUrl} alt={title} size="sm" />
         <div class="flex-1 min-w-0">
           <div class="flex items-start justify-between gap-2">
-            <BookMeta
-              title={title}
-              authors={authors}
-              publisher={publisher}
-            />
+            <BookMeta title={title} authors={authors} publisher={publisher} />
             <StatusBadge status={status} class="shrink-0" />
           </div>
           {pageCount > 0 && (
             <div class="mt-3">
-              <ProgressBar
-                current={currentPage}
-                total={pageCount}
-                showLabel={true}
-              />
+              <ProgressBar current={currentPage} total={pageCount} showLabel={true} />
             </div>
           )}
         </div>

--- a/app/components/book/BookCover.tsx
+++ b/app/components/book/BookCover.tsx
@@ -15,12 +15,7 @@ const sizeStyles: Record<CoverSize, string> = {
   lg: "w-32 h-48",
 };
 
-export const BookCover: FC<BookCoverProps> = ({
-  src,
-  alt,
-  size = "md",
-  class: className = "",
-}) => {
+export const BookCover: FC<BookCoverProps> = ({ src, alt, size = "md", class: className = "" }) => {
   if (src) {
     return (
       <img
@@ -35,9 +30,7 @@ export const BookCover: FC<BookCoverProps> = ({
     <div
       class={`bg-zinc-100 rounded-md shadow-sm border border-zinc-200 flex items-center justify-center ${sizeStyles[size]} ${className}`}
     >
-      <span class="text-zinc-400 text-[10px] uppercase font-medium text-center px-1">
-        No Image
-      </span>
+      <span class="text-zinc-400 text-[10px] uppercase font-medium text-center px-1">No Image</span>
     </div>
   );
 };

--- a/app/components/book/BookList.tsx
+++ b/app/components/book/BookList.tsx
@@ -18,10 +18,7 @@ interface BookListProps {
   emptyMessage?: string;
 }
 
-export const BookList: FC<BookListProps> = ({
-  books,
-  emptyMessage = "本がありません",
-}) => {
+export const BookList: FC<BookListProps> = ({ books, emptyMessage = "本がありません" }) => {
   if (books.length === 0) {
     return (
       <div class="text-center py-12">

--- a/app/components/book/BookMeta.tsx
+++ b/app/components/book/BookMeta.tsx
@@ -15,9 +15,7 @@ export const BookMeta: FC<BookMetaProps> = ({
 }) => {
   return (
     <div class={className}>
-      <h3 class="font-bold text-zinc-900 line-clamp-2 tracking-tight leading-snug">
-        {title}
-      </h3>
+      <h3 class="font-bold text-zinc-900 line-clamp-2 tracking-tight leading-snug">{title}</h3>
       <p class="text-xs font-medium text-zinc-600 mt-1 uppercase tracking-wide">
         {authors.join(", ")}
       </p>

--- a/app/components/book/BookSearchResult.tsx
+++ b/app/components/book/BookSearchResult.tsx
@@ -10,23 +10,14 @@ interface BookSearchResultProps {
   onSelect?: string;
 }
 
-export const BookSearchResultItem: FC<BookSearchResultProps> = ({
-  book,
-  onSelect,
-}) => {
+export const BookSearchResultItem: FC<BookSearchResultProps> = ({ book, onSelect }) => {
   return (
     <Card class="hover:bg-gray-50">
       <CardBody class="flex gap-4">
         <BookCover src={book.thumbnailUrl} alt={book.title} size="sm" />
         <div class="flex-1 min-w-0">
-          <BookMeta
-            title={book.title}
-            authors={book.authors}
-            publisher={book.publisher}
-          />
-          {book.isbn && (
-            <p class="text-xs text-gray-400 mt-1">ISBN: {book.isbn}</p>
-          )}
+          <BookMeta title={book.title} authors={book.authors} publisher={book.publisher} />
+          {book.isbn && <p class="text-xs text-gray-400 mt-1">ISBN: {book.isbn}</p>}
         </div>
         <div class="flex items-center">
           <Button size="sm" variant="secondary" onClick={onSelect}>
@@ -43,24 +34,15 @@ interface BookSearchResultListProps {
   onSelect?: (book: SearchResult) => void;
 }
 
-export const BookSearchResultList: FC<BookSearchResultListProps> = ({
-  results,
-}) => {
+export const BookSearchResultList: FC<BookSearchResultListProps> = ({ results }) => {
   if (results.length === 0) {
-    return (
-      <div class="text-center py-8 text-gray-500">
-        検索結果がありません
-      </div>
-    );
+    return <div class="text-center py-8 text-gray-500">検索結果がありません</div>;
   }
 
   return (
     <div class="space-y-3">
       {results.map((book) => (
-        <BookSearchResultItem
-          key={book.isbn || book.title}
-          book={book}
-        />
+        <BookSearchResultItem key={book.isbn || book.title} book={book} />
       ))}
     </div>
   );

--- a/app/components/common/EmptyState.tsx
+++ b/app/components/common/EmptyState.tsx
@@ -17,12 +17,8 @@ export const EmptyState: FC<PropsWithChildren<EmptyStateProps>> = ({
   return (
     <div class="text-center py-12">
       {children}
-      <h3 class="mt-4 text-lg font-bold tracking-tight text-zinc-900">
-        {title}
-      </h3>
-      {description && (
-        <p class="mt-2 text-zinc-500 max-w-sm mx-auto">{description}</p>
-      )}
+      <h3 class="mt-4 text-lg font-bold tracking-tight text-zinc-900">{title}</h3>
+      {description && <p class="mt-2 text-zinc-500 max-w-sm mx-auto">{description}</p>}
       {actionHref && actionLabel && (
         <a
           href={actionHref}

--- a/app/components/common/ErrorMessage.tsx
+++ b/app/components/common/ErrorMessage.tsx
@@ -15,11 +15,7 @@ export const ErrorMessage: FC<ErrorMessageProps> = ({
     <div class={`bg-red-50 border border-red-200 rounded-md p-4 ${className}`}>
       <div class="flex">
         <div class="shrink-0">
-          <svg
-            class="h-5 w-5 text-red-400"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
+          <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
             <path
               fill-rule="evenodd"
               d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"

--- a/app/components/common/LoadingSpinner.tsx
+++ b/app/components/common/LoadingSpinner.tsx
@@ -11,10 +11,7 @@ const sizeStyles: Record<string, string> = {
   lg: "w-12 h-12",
 };
 
-export const LoadingSpinner: FC<LoadingSpinnerProps> = ({
-  size = "md",
-  class: className = "",
-}) => {
+export const LoadingSpinner: FC<LoadingSpinnerProps> = ({ size = "md", class: className = "" }) => {
   return (
     <div
       class={`animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900 ${sizeStyles[size]} ${className}`}

--- a/app/components/landing/HeroVisual.tsx
+++ b/app/components/landing/HeroVisual.tsx
@@ -25,7 +25,9 @@ export function HeroVisual({
 
   return (
     <div class={`min-w-0 items-center justify-center relative ${className}`}>
-      <div class={`min-w-0 relative z-10 w-full flex items-center justify-center overflow-hidden ${cloudOffsetClass}`}>
+      <div
+        class={`min-w-0 relative z-10 w-full flex items-center justify-center overflow-hidden ${cloudOffsetClass}`}
+      >
         <IconCloud images={techIcons} width={cloudSize} height={cloudSize} />
       </div>
 
@@ -46,25 +48,13 @@ export function HeroVisual({
               <stop offset="100%" stop-color="#18181b" />
             </linearGradient>
 
-            <linearGradient
-              id={pageGradLeftId}
-              x1="0%"
-              y1="0%"
-              x2="100%"
-              y2="0%"
-            >
+            <linearGradient id={pageGradLeftId} x1="0%" y1="0%" x2="100%" y2="0%">
               <stop offset="0%" stop-color="#e4e4e7" />
               <stop offset="90%" stop-color="#a1a1aa" />
               <stop offset="100%" stop-color="#71717a" />
             </linearGradient>
 
-            <linearGradient
-              id={pageGradRightId}
-              x1="0%"
-              y1="0%"
-              x2="100%"
-              y2="0%"
-            >
+            <linearGradient id={pageGradRightId} x1="0%" y1="0%" x2="100%" y2="0%">
               <stop offset="0%" stop-color="#71717a" />
               <stop offset="10%" stop-color="#a1a1aa" />
               <stop offset="100%" stop-color="#e4e4e7" />
@@ -99,43 +89,13 @@ export function HeroVisual({
           />
 
           <g opacity="0.1">
-            <path
-              d="M55 50 Q130 40, 200 55"
-              stroke="#000"
-              stroke-width="1"
-              fill="none"
-            />
-            <path
-              d="M55 65 Q130 55, 200 70"
-              stroke="#000"
-              stroke-width="1"
-              fill="none"
-            />
-            <path
-              d="M55 80 Q130 70, 200 85"
-              stroke="#000"
-              stroke-width="1"
-              fill="none"
-            />
+            <path d="M55 50 Q130 40, 200 55" stroke="#000" stroke-width="1" fill="none" />
+            <path d="M55 65 Q130 55, 200 70" stroke="#000" stroke-width="1" fill="none" />
+            <path d="M55 80 Q130 70, 200 85" stroke="#000" stroke-width="1" fill="none" />
 
-            <path
-              d="M240 55 Q310 40, 385 50"
-              stroke="#000"
-              stroke-width="1"
-              fill="none"
-            />
-            <path
-              d="M240 70 Q310 55, 385 65"
-              stroke="#000"
-              stroke-width="1"
-              fill="none"
-            />
-            <path
-              d="M240 85 Q310 70, 385 80"
-              stroke="#000"
-              stroke-width="1"
-              fill="none"
-            />
+            <path d="M240 55 Q310 40, 385 50" stroke="#000" stroke-width="1" fill="none" />
+            <path d="M240 70 Q310 55, 385 65" stroke="#000" stroke-width="1" fill="none" />
+            <path d="M240 85 Q310 70, 385 80" stroke="#000" stroke-width="1" fill="none" />
           </g>
         </svg>
       </div>

--- a/app/components/layout/Container.tsx
+++ b/app/components/layout/Container.tsx
@@ -19,10 +19,6 @@ export const Container: FC<PropsWithChildren<ContainerProps>> = ({
   size = "xl",
 }) => {
   return (
-    <div
-      class={`${sizeStyles[size]} mx-auto px-4 sm:px-6 lg:px-8 ${className}`}
-    >
-      {children}
-    </div>
+    <div class={`${sizeStyles[size]} mx-auto px-4 sm:px-6 lg:px-8 ${className}`}>{children}</div>
   );
 };

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -20,10 +20,7 @@ export const Header: FC<HeaderProps> = ({ user }) => {
               <Avatar src={user.avatar_url} alt={user.name} size="md" />
             </div>
             <div class="md:hidden">
-              <AvatarMenu
-                avatarUrl={user.avatar_url}
-                name={user.name}
-              />
+              <AvatarMenu avatarUrl={user.avatar_url} name={user.name} />
             </div>
           </div>
         ) : (

--- a/app/components/ui/Avatar.tsx
+++ b/app/components/ui/Avatar.tsx
@@ -16,12 +16,7 @@ const sizeStyles: Record<AvatarSize, string> = {
   xl: "w-16 h-16 text-lg",
 };
 
-export const Avatar: FC<AvatarProps> = ({
-  src,
-  alt,
-  size = "md",
-  class: className = "",
-}) => {
+export const Avatar: FC<AvatarProps> = ({ src, alt, size = "md", class: className = "" }) => {
   const initials = alt
     .split(" ")
     .map((n) => n[0])

--- a/app/components/ui/Badge.tsx
+++ b/app/components/ui/Badge.tsx
@@ -30,10 +30,7 @@ export const Badge: FC<PropsWithChildren<BadgeProps>> = ({
   );
 };
 
-const statusConfig: Record<
-  BookStatus,
-  { label: string; variant: BadgeVariant }
-> = {
+const statusConfig: Record<BookStatus, { label: string; variant: BadgeVariant }> = {
   unread: { label: "積読", variant: "default" },
   reading: { label: "読書中", variant: "info" },
   completed: { label: "読了", variant: "success" },
@@ -44,10 +41,7 @@ interface StatusBadgeProps {
   class?: string;
 }
 
-export const StatusBadge: FC<StatusBadgeProps> = ({
-  status,
-  class: className = "",
-}) => {
+export const StatusBadge: FC<StatusBadgeProps> = ({ status, class: className = "" }) => {
   const config = statusConfig[status];
   return (
     <Badge variant={config.variant} class={className}>

--- a/app/components/ui/Button.tsx
+++ b/app/components/ui/Button.tsx
@@ -1,11 +1,6 @@
 import type { FC, PropsWithChildren, CSSProperties } from "hono/jsx";
 
-type ButtonVariant =
-  | "primary"
-  | "secondary"
-  | "danger"
-  | "danger-soft"
-  | "ghost";
+type ButtonVariant = "primary" | "secondary" | "danger" | "danger-soft" | "ghost";
 type ButtonSize = "sm" | "md" | "lg";
 type ButtonShape = "md" | "pill" | "xl";
 type ButtonWeight = "medium" | "bold";
@@ -33,8 +28,7 @@ const variantStyles: Record<ButtonVariant, string> = {
     "bg-white text-red-600 border border-red-100 hover:bg-red-50 hover:text-red-700 shadow-sm focus:ring-red-500",
   "danger-soft":
     "bg-red-50 text-red-600 border border-red-100 hover:bg-red-100 shadow-sm focus:ring-red-500",
-  ghost:
-    "bg-transparent text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 focus:ring-zinc-900",
+  ghost: "bg-transparent text-zinc-600 hover:bg-zinc-100 hover:text-zinc-900 focus:ring-zinc-900",
 };
 
 const sizeStyles: Record<ButtonSize, string> = {

--- a/app/components/ui/Card.tsx
+++ b/app/components/ui/Card.tsx
@@ -30,11 +30,7 @@ export const CardHeader: FC<PropsWithChildren<{ class?: string }>> = ({
   children,
   class: className = "",
 }) => {
-  return (
-    <div class={`px-6 py-4 border-b border-zinc-100 ${className}`}>
-      {children}
-    </div>
-  );
+  return <div class={`px-6 py-4 border-b border-zinc-100 ${className}`}>{children}</div>;
 };
 
 export const CardBody: FC<PropsWithChildren<{ class?: string }>> = ({
@@ -49,9 +45,7 @@ export const CardFooter: FC<PropsWithChildren<{ class?: string }>> = ({
   class: className = "",
 }) => {
   return (
-    <div
-      class={`px-6 py-4 border-t border-zinc-100 bg-zinc-50/50 rounded-b-xl ${className}`}
-    >
+    <div class={`px-6 py-4 border-t border-zinc-100 bg-zinc-50/50 rounded-b-xl ${className}`}>
       {children}
     </div>
   );

--- a/app/components/user/UserProfile.tsx
+++ b/app/components/user/UserProfile.tsx
@@ -8,21 +8,19 @@ interface UserProfileProps {
   avatarUrl?: string | null;
 }
 
-export const UserProfile: FC<UserProfileProps> = ({
-  username,
-  name,
-  bio,
-  avatarUrl,
-}) => {
+export const UserProfile: FC<UserProfileProps> = ({ username, name, bio, avatarUrl }) => {
   return (
     <div class="flex items-start gap-6">
-      <Avatar src={avatarUrl} alt={name} size="xl" class="w-20 h-20 ring-4 ring-zinc-50 shadow-sm" />
+      <Avatar
+        src={avatarUrl}
+        alt={name}
+        size="xl"
+        class="w-20 h-20 ring-4 ring-zinc-50 shadow-sm"
+      />
       <div class="flex-1">
         <h1 class="text-3xl font-bold tracking-tight text-zinc-900 mb-1">{name}</h1>
         <p class="text-zinc-500 font-medium mb-3">@{username}</p>
-        {bio && (
-          <p class="text-zinc-600 leading-relaxed max-w-2xl">{bio}</p>
-        )}
+        {bio && <p class="text-zinc-600 leading-relaxed max-w-2xl">{bio}</p>}
       </div>
     </div>
   );

--- a/app/components/user/UserStats.tsx
+++ b/app/components/user/UserStats.tsx
@@ -6,11 +6,7 @@ interface UserStatsProps {
   completedBooks: number;
 }
 
-export const UserStats: FC<UserStatsProps> = ({
-  totalBooks,
-  readingBooks,
-  completedBooks,
-}) => {
+export const UserStats: FC<UserStatsProps> = ({ totalBooks, readingBooks, completedBooks }) => {
   return (
     <div class="flex items-center gap-8 text-zinc-600">
       <div class="flex items-baseline gap-2">

--- a/app/islands/BookSearchForm.tsx
+++ b/app/islands/BookSearchForm.tsx
@@ -35,7 +35,6 @@ export default function BookSearchForm() {
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
 
-
   const handleSearch = async () => {
     if (!query.trim()) return;
 
@@ -44,13 +43,11 @@ export default function BookSearchForm() {
     setCurrentPage(1);
 
     try {
-      const res = await fetch(
-        `/api/search/books?query=${encodeURIComponent(query)}&page=1`
-      );
+      const res = await fetch(`/api/search/books?query=${encodeURIComponent(query)}&page=1`);
       const data = (await res.json()) as ApiResponse<SearchResponse>;
 
-      if (data.success && data.data) {        
-        setResults(data.data.results);        
+      if (data.success && data.data) {
+        setResults(data.data.results);
         setHasMore(data.data.currentPage < data.data.pageCount);
         setCurrentPage(data.data.currentPage);
       } else {
@@ -71,7 +68,7 @@ export default function BookSearchForm() {
 
     try {
       const res = await fetch(
-        `/api/search/books?query=${encodeURIComponent(query)}&page=${nextPage}`
+        `/api/search/books?query=${encodeURIComponent(query)}&page=${nextPage}`,
       );
       const data = (await res.json()) as ApiResponse<SearchResponse>;
 
@@ -157,15 +154,10 @@ export default function BookSearchForm() {
           {loading ? "検索中..." : "検索"}
         </button>
       </div>
-      
+
       {error && (
         <div class="p-4 bg-red-50 border border-red-100 rounded-lg text-red-600 text-sm flex items-center gap-2">
-          <svg
-            class="w-5 h-5"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
@@ -200,12 +192,8 @@ export default function BookSearchForm() {
 
               <div class="flex-1 min-w-0 flex flex-col">
                 <div class="flex-1">
-                  <h4 class="font-bold text-zinc-900 line-clamp-2 mb-1">
-                    {book.title}
-                  </h4>
-                  <p class="text-sm text-zinc-600 mb-1">
-                    {book.authors.join(", ")}
-                  </p>
+                  <h4 class="font-bold text-zinc-900 line-clamp-2 mb-1">{book.title}</h4>
+                  <p class="text-sm text-zinc-600 mb-1">{book.authors.join(", ")}</p>
                   <div class="flex flex-wrap gap-x-3 gap-y-1 text-xs text-zinc-500">
                     {book.publisher && <span>{book.publisher}</span>}
                     {book.publishedDate && <span>{book.publishedDate}</span>}

--- a/app/islands/BooksStatusTabs.tsx
+++ b/app/islands/BooksStatusTabs.tsx
@@ -20,10 +20,7 @@ type TabKey = "reading" | "unread" | "completed";
 
 const tabOrder: TabKey[] = ["reading", "unread", "completed"];
 
-const getDefaultTab = (
-  tabs: Record<TabKey, BookItem[]>,
-  initialTab?: BookStatus
-): TabKey => {
+const getDefaultTab = (tabs: Record<TabKey, BookItem[]>, initialTab?: BookStatus): TabKey => {
   if (initialTab && tabOrder.includes(initialTab)) {
     return initialTab;
   }
@@ -38,20 +35,14 @@ const getDefaultTab = (
 const filterByStatus = (books: BookItem[], status: TabKey) =>
   books.filter((book) => book.status === status);
 
-export default function BooksStatusTabs({
-  books,
-  total,
-  initialTab,
-}: BooksStatusTabsProps) {
+export default function BooksStatusTabs({ books, total, initialTab }: BooksStatusTabsProps) {
   const tabs = {
     reading: filterByStatus(books, "reading"),
     unread: filterByStatus(books, "unread"),
     completed: filterByStatus(books, "completed"),
   } satisfies Record<TabKey, BookItem[]>;
 
-  const [activeTab, setActiveTab] = useState<TabKey>(
-    getDefaultTab(tabs, initialTab)
-  );
+  const [activeTab, setActiveTab] = useState<TabKey>(getDefaultTab(tabs, initialTab));
 
   const tabItems = [
     { key: "reading" as const, label: "読書中", count: tabs.reading.length },
@@ -128,9 +119,7 @@ export default function BooksStatusTabs({
                       <h3 class="font-semibold text-zinc-900 text-sm leading-snug line-clamp-2 group-hover:text-blue-600 transition-colors">
                         {book.title}
                       </h3>
-                      <p class="text-xs text-zinc-500 line-clamp-1">
-                        {book.authors.join(", ")}
-                      </p>
+                      <p class="text-xs text-zinc-500 line-clamp-1">{book.authors.join(", ")}</p>
                     </div>
                   </a>
                 ))}
@@ -154,9 +143,7 @@ export default function BooksStatusTabs({
                     />
                   </svg>
                 </div>
-                <h3 class="text-lg font-bold text-zinc-900 mb-1">
-                  本が見つかりません
-                </h3>
+                <h3 class="text-lg font-bold text-zinc-900 mb-1">本が見つかりません</h3>
                 <p class="text-zinc-500 mb-8 max-w-sm mx-auto text-sm">
                   条件に一致する本が見つかりませんでした。検索条件を変更するか、新しい本を追加してください。
                 </p>

--- a/app/islands/IconCloud.tsx
+++ b/app/islands/IconCloud.tsx
@@ -45,11 +45,7 @@ function useResponsiveSize(baseWidth: number, baseHeight: number) {
   return { containerRef, ...size };
 }
 
-export default function IconCloud({
-  images,
-  width = 400,
-  height = 400,
-}: IconCloudProps) {
+export default function IconCloud({ images, width = 400, height = 400 }: IconCloudProps) {
   const {
     containerRef,
     width: resolvedWidth,
@@ -91,7 +87,7 @@ export default function IconCloud({
   useEffect(() => {
     if (!images || images.length === 0) return;
 
-    imagesLoadedRef.current = new Array(images.length).fill(false);
+    imagesLoadedRef.current = Array.from({ length: images.length }, () => false);
 
     const newIconCanvases = images.map((imageUrl, index) => {
       const offscreen = document.createElement("canvas");
@@ -108,13 +104,7 @@ export default function IconCloud({
 
           // Draw the image slightly smaller (80% of size) with transparent background
           const padding = iconSize * 0.1; // 10% padding on each side
-          offCtx.drawImage(
-            img,
-            padding,
-            padding,
-            iconSize - padding * 2,
-            iconSize - padding * 2,
-          );
+          offCtx.drawImage(img, padding, padding, iconSize - padding * 2, iconSize - padding * 2);
 
           if (imagesLoadedRef.current) {
             imagesLoadedRef.current[index] = true;
@@ -193,10 +183,7 @@ export default function IconCloud({
       const dy = y - screenY;
 
       if (dx * dx + dy * dy < clickRadius * clickRadius) {
-        const targetX = -Math.atan2(
-          icon.y,
-          Math.sqrt(icon.x * icon.x + icon.z * icon.z),
-        );
+        const targetX = -Math.atan2(icon.y, Math.sqrt(icon.x * icon.x + icon.z * icon.z));
         const targetY = Math.atan2(icon.x, icon.z);
 
         const currentX = rot.x;
@@ -279,12 +266,8 @@ export default function IconCloud({
         const easedProgress = easeOutCubic(progress);
 
         rotationRef.current = {
-          x:
-            targetRotation.startX +
-            (targetRotation.x - targetRotation.startX) * easedProgress,
-          y:
-            targetRotation.startY +
-            (targetRotation.y - targetRotation.startY) * easedProgress,
+          x: targetRotation.startX + (targetRotation.x - targetRotation.startX) * easedProgress,
+          y: targetRotation.startY + (targetRotation.y - targetRotation.startY) * easedProgress,
         };
 
         if (progress >= 1) {
@@ -320,23 +303,14 @@ export default function IconCloud({
         const opacity = Math.max(0.2, Math.min(1, (icon.rotatedZ + 150) / 200));
 
         ctx.save();
-        ctx.translate(
-          canvas.width / 2 + icon.rotatedX,
-          canvas.height / 2 + icon.rotatedY,
-        );
+        ctx.translate(canvas.width / 2 + icon.rotatedX, canvas.height / 2 + icon.rotatedY);
         ctx.scale(scale, scale);
         ctx.globalAlpha = opacity;
 
         const iconCanvases = iconCanvasesRef.current ?? [];
         const imagesLoaded = imagesLoadedRef.current ?? [];
         if (iconCanvases[icon.id] && imagesLoaded[icon.id]) {
-          ctx.drawImage(
-            iconCanvases[icon.id],
-            -iconRadius,
-            -iconRadius,
-            iconSize,
-            iconSize,
-          );
+          ctx.drawImage(iconCanvases[icon.id], -iconRadius, -iconRadius, iconSize, iconSize);
         } else {
           // Fallback: show a placeholder circle while loading
           ctx.beginPath();
@@ -361,11 +335,7 @@ export default function IconCloud({
   }, [images, iconPositions, isDragging, mousePos, targetRotation, isMobile]);
 
   return (
-    <div
-      ref={containerRef}
-      class="w-full aspect-square mx-auto"
-      style={{ maxWidth: `${width}px` }}
-    >
+    <div ref={containerRef} class="w-full aspect-square mx-auto" style={{ maxWidth: `${width}px` }}>
       <canvas
         ref={canvasRef}
         width={resolvedWidth}

--- a/app/islands/ProfileBookTabs.tsx
+++ b/app/islands/ProfileBookTabs.tsx
@@ -120,9 +120,7 @@ export default function ProfileBookTabs({
                       <h3 class="font-semibold text-zinc-900 text-sm leading-snug line-clamp-2 group-hover:text-blue-600 transition-colors">
                         {book.title}
                       </h3>
-                      <p class="text-xs text-zinc-500 line-clamp-1">
-                        {book.authors.join(", ")}
-                      </p>
+                      <p class="text-xs text-zinc-500 line-clamp-1">{book.authors.join(", ")}</p>
                     </div>
                   </a>
                 ))}
@@ -149,9 +147,7 @@ export default function ProfileBookTabs({
                   <h3 class="text-lg font-bold tracking-tight text-zinc-900 mb-2">
                     まだ公開されている本がありません
                   </h3>
-                  <p class="text-zinc-500 text-sm">
-                    {userName}さんの読書記録はまだありません
-                  </p>
+                  <p class="text-zinc-500 text-sm">{userName}さんの読書記録はまだありません</p>
                 </CardBody>
               </Card>
             )}

--- a/app/islands/ProfileForm.tsx
+++ b/app/islands/ProfileForm.tsx
@@ -27,10 +27,7 @@ export default function ProfileForm({
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
-  const hasChanges =
-    username !== initialUsername ||
-    name !== initialName ||
-    bio !== initialBio;
+  const hasChanges = username !== initialUsername || name !== initialName || bio !== initialBio;
 
   const handleSave = async () => {
     if (!hasChanges) return;
@@ -81,18 +78,13 @@ export default function ProfileForm({
         )}
         <div class="flex-1">
           <p class="text-sm font-bold text-zinc-900 mb-1">プロフィール画像</p>
-          <p class="text-xs text-zinc-500">
-            {providerName}のアカウント写真を使用中
-          </p>
+          <p class="text-xs text-zinc-500">{providerName}のアカウント写真を使用中</p>
         </div>
       </div>
 
       <div class="space-y-6">
         <div>
-          <label
-            for="username"
-            class="mb-2 block text-sm font-bold text-zinc-700"
-          >
+          <label for="username" class="mb-2 block text-sm font-bold text-zinc-700">
             ユーザーID
           </label>
           <div class="flex rounded-xl shadow-sm ring-1 ring-zinc-200 overflow-hidden">
@@ -103,9 +95,7 @@ export default function ProfileForm({
               type="text"
               id="username"
               value={username}
-              onInput={(e) =>
-                setUsername((e.target as HTMLInputElement).value)
-              }
+              onInput={(e) => setUsername((e.target as HTMLInputElement).value)}
               class="w-full px-3 py-2 rounded-none border-0 focus:ring-0 bg-white focus:outline-none text-zinc-900"
             />
           </div>
@@ -135,16 +125,12 @@ export default function ProfileForm({
             rows={4}
             class="w-full px-3 py-2 border border-zinc-200 rounded-xl bg-zinc-50 focus:bg-white focus:outline-none focus:ring-2 focus:ring-zinc-900 focus:border-transparent transition-colors resize-vertical text-zinc-900"
           />
-          <p class="mt-2 text-xs text-zinc-500 font-medium">
-            簡単な自己紹介を書いてください。
-          </p>
+          <p class="mt-2 text-xs text-zinc-500 font-medium">簡単な自己紹介を書いてください。</p>
         </div>
       </div>
 
       <div class="flex items-center justify-end gap-3 pt-4 border-t border-zinc-50">
-        {saved && (
-          <span class="text-sm text-zinc-500">保存しました</span>
-        )}
+        {saved && <span class="text-sm text-zinc-500">保存しました</span>}
         <button
           type="button"
           onClick={handleSave}

--- a/app/islands/ProgressSlider.tsx
+++ b/app/islands/ProgressSlider.tsx
@@ -11,17 +11,12 @@ interface ApiResponse {
   error?: { message: string };
 }
 
-export default function ProgressSlider({
-  bookId,
-  initialPage,
-  totalPages,
-}: ProgressSliderProps) {
+export default function ProgressSlider({ bookId, initialPage, totalPages }: ProgressSliderProps) {
   const [currentPage, setCurrentPage] = useState(initialPage);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
-  const percentage =
-    totalPages > 0 ? Math.round((currentPage / totalPages) * 100) : 0;
+  const percentage = totalPages > 0 ? Math.round((currentPage / totalPages) * 100) : 0;
 
   const handleUpdate = async () => {
     if (currentPage === initialPage) return;
@@ -73,9 +68,7 @@ export default function ProgressSlider({
             min="0"
             max={totalPages}
             value={currentPage}
-            onInput={(e) =>
-              setCurrentPage(Number((e.target as HTMLInputElement).value))
-            }
+            onInput={(e) => setCurrentPage(Number((e.target as HTMLInputElement).value))}
             class="absolute w-full h-full opacity-0 z-10 cursor-pointer"
           />
           <div class="w-full h-2 bg-zinc-100 rounded-full overflow-hidden absolute top-1/2 -translate-y-1/2">
@@ -98,11 +91,7 @@ export default function ProgressSlider({
         <div class="flex gap-2">
           {[-10, 10, 50].map((step) => (
             <button
-              onClick={() =>
-                setCurrentPage(
-                  Math.max(0, Math.min(totalPages, currentPage + step))
-                )
-              }
+              onClick={() => setCurrentPage(Math.max(0, Math.min(totalPages, currentPage + step)))}
               class="px-3 py-1.5 text-xs font-medium text-zinc-600 bg-white border border-zinc-200 rounded-md hover:bg-zinc-50 hover:text-zinc-900 hover:border-zinc-300 transition-colors"
             >
               {step > 0 ? `+${step}` : step}
@@ -111,11 +100,7 @@ export default function ProgressSlider({
         </div>
 
         <div class="flex items-center gap-3">
-          {saved && (
-            <span class="text-sm text-zinc-500 animate-fade-in">
-              保存しました
-            </span>
-          )}
+          {saved && <span class="text-sm text-zinc-500 animate-fade-in">保存しました</span>}
           <button
             onClick={handleUpdate}
             disabled={saving || currentPage === initialPage}

--- a/app/islands/ReadingBooksCarousel.tsx
+++ b/app/islands/ReadingBooksCarousel.tsx
@@ -14,9 +14,7 @@ interface ReadingBooksCarouselProps {
   books: ReadingBook[];
 }
 
-export default function ReadingBooksCarousel({
-  books,
-}: ReadingBooksCarouselProps) {
+export default function ReadingBooksCarousel({ books }: ReadingBooksCarouselProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const scroll = (direction: "left" | "right") => {
@@ -73,12 +71,7 @@ export default function ReadingBooksCarousel({
           >
             <div class="flex gap-4 mb-4">
               <div class="shrink-0">
-                <BookCover
-                  src={book.thumbnailUrl}
-                  alt={book.title}
-                  size="md"
-                  class="shadow-sm"
-                />
+                <BookCover src={book.thumbnailUrl} alt={book.title} size="md" class="shadow-sm" />
               </div>
               <div class="flex-1 min-w-0">
                 <h3
@@ -100,9 +93,7 @@ export default function ReadingBooksCarousel({
             {book.pageCount > 0 && (
               <div class="mt-auto pt-2">
                 <div class="flex justify-between text-[10px] font-bold uppercase tracking-wider text-zinc-900 mb-2">
-                  <span style={{ fontFamily: '"Arial", sans-serif' }}>
-                    Progress
-                  </span>
+                  <span style={{ fontFamily: '"Arial", sans-serif' }}>Progress</span>
                   <span style={{ fontFamily: '"Arial", sans-serif' }}>
                     {Math.round((book.currentPage / book.pageCount) * 100)}%
                   </span>
@@ -111,10 +102,7 @@ export default function ReadingBooksCarousel({
                   <div
                     class="h-full bg-zinc-900 transition-all duration-500 ease-out"
                     style={{
-                      width: `${Math.min(
-                        100,
-                        (book.currentPage / book.pageCount) * 100,
-                      )}%`,
+                      width: `${Math.min(100, (book.currentPage / book.pageCount) * 100)}%`,
                     }}
                   />
                 </div>

--- a/app/islands/StatusToggle.tsx
+++ b/app/islands/StatusToggle.tsx
@@ -18,10 +18,7 @@ const statusOptions: { value: BookStatus; label: string }[] = [
   { value: "completed", label: "読了" },
 ];
 
-export default function StatusToggle({
-  bookId,
-  currentStatus,
-}: StatusToggleProps) {
+export default function StatusToggle({ bookId, currentStatus }: StatusToggleProps) {
   const [status, setStatus] = useState<BookStatus>(currentStatus);
   const [saving, setSaving] = useState(false);
 
@@ -53,20 +50,20 @@ export default function StatusToggle({
   return (
     <div class="flex w-full justify-center">
       <div class="inline-flex items-center gap-1 p-1 bg-zinc-100 rounded-lg">
-      {statusOptions.map((option) => (
-        <button
-          key={option.value}
-          onClick={() => handleChange(option.value)}
-          disabled={saving}
-          class={`px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-200 ${
-            status === option.value
-              ? "bg-white text-zinc-900 shadow-sm"
-              : "text-zinc-500 hover:text-zinc-700 hover:bg-zinc-200/50"
-          } disabled:opacity-50`}
-        >
-          {option.label}
-        </button>
-      ))}
+        {statusOptions.map((option) => (
+          <button
+            key={option.value}
+            onClick={() => handleChange(option.value)}
+            disabled={saving}
+            class={`px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-200 ${
+              status === option.value
+                ? "bg-white text-zinc-900 shadow-sm"
+                : "text-zinc-500 hover:text-zinc-700 hover:bg-zinc-200/50"
+            } disabled:opacity-50`}
+          >
+            {option.label}
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/app/islands/TagInput.tsx
+++ b/app/islands/TagInput.tsx
@@ -112,8 +112,7 @@ export default function TagInput({ bookId, initialTags = [] }: TagInputProps) {
 
   const suggestions = allTags.filter(
     (t) =>
-      t.name.toLowerCase().includes(input.toLowerCase()) &&
-      !tags.some((tag) => tag.id === t.id)
+      t.name.toLowerCase().includes(input.toLowerCase()) && !tags.some((tag) => tag.id === t.id),
   );
 
   return (

--- a/app/islands/desktop/Sidebar.tsx
+++ b/app/islands/desktop/Sidebar.tsx
@@ -8,10 +8,7 @@ interface SidebarProps {
   showLogout?: boolean;
 }
 
-export default function Sidebar({
-  initialExpanded = false,
-  showLogout = true,
-}: SidebarProps) {
+export default function Sidebar({ initialExpanded = false, showLogout = true }: SidebarProps) {
   const [isExpanded, setIsExpanded] = useState(initialExpanded);
 
   const navItems = [

--- a/app/islands/mobile/AvatarMenu.tsx
+++ b/app/islands/mobile/AvatarMenu.tsx
@@ -6,11 +6,7 @@ interface AvatarMenuProps {
   showLogout?: boolean;
 }
 
-export default function AvatarMenu({
-  avatarUrl,
-  name,
-  showLogout = true,
-}: AvatarMenuProps) {
+export default function AvatarMenu({ avatarUrl, name, showLogout = true }: AvatarMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -53,11 +49,7 @@ export default function AvatarMenu({
         aria-label="ユーザーメニュー"
       >
         {avatarUrl ? (
-          <img
-            src={avatarUrl}
-            alt={name}
-            class="w-10 h-10 rounded-full object-cover"
-          />
+          <img src={avatarUrl} alt={name} class="w-10 h-10 rounded-full object-cover" />
         ) : (
           <div class="w-10 h-10 rounded-full bg-zinc-200 flex items-center justify-center font-medium text-sm text-zinc-600">
             {initials}

--- a/app/islands/mobile/Sidebar.tsx
+++ b/app/islands/mobile/Sidebar.tsx
@@ -98,9 +98,7 @@ export default function Sidebar({ showLogout = true }: SidebarProps) {
           <aside class="relative w-72 max-w-[80vw] bg-zinc-950 flex flex-col h-full shadow-2xl animate-slide-in">
             <div class="h-16 flex items-center justify-between px-5 shrink-0 mt-3">
               <a href="/" class="flex items-center">
-                <span class="text-2xl font-bold tracking-tight text-white">
-                  gidoku
-                </span>
+                <span class="text-2xl font-bold tracking-tight text-white">gidoku</span>
               </a>
               <button
                 type="button"
@@ -141,9 +139,7 @@ export default function Sidebar({ showLogout = true }: SidebarProps) {
                         style="width:20px;height:20px"
                       />
                     </span>
-                    <span class="text-sm font-medium text-zinc-300">
-                      {item.label}
-                    </span>
+                    <span class="text-sm font-medium text-zinc-300">{item.label}</span>
                   </a>
                 ))}
               </div>

--- a/app/routes/_404.tsx
+++ b/app/routes/_404.tsx
@@ -1,8 +1,8 @@
-import type { NotFoundHandler } from 'hono'
+import type { NotFoundHandler } from "hono";
 
 const handler: NotFoundHandler = (c) => {
-  c.status(404)
-  return c.render('404 Not Found')
-}
+  c.status(404);
+  return c.render("404 Not Found");
+};
 
-export default handler
+export default handler;

--- a/app/routes/_error.tsx
+++ b/app/routes/_error.tsx
@@ -1,12 +1,12 @@
-import type { ErrorHandler } from 'hono'
+import type { ErrorHandler } from "hono";
 
 const handler: ErrorHandler = (e, c) => {
-  if ('getResponse' in e) {
-    return e.getResponse()
+  if ("getResponse" in e) {
+    return e.getResponse();
   }
-  console.error(e.message)
-  c.status(500)
-  return c.render('Internal Server Error')
-}
+  console.error(e.message);
+  c.status(500);
+  return c.render("Internal Server Error");
+};
 
-export default handler
+export default handler;

--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -12,11 +12,7 @@ export default jsxRenderer(({ children }) => {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="icon" href="/favicon.ico" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossorigin=""
-        />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
         <link
           href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap"
           rel="stylesheet"

--- a/app/routes/books/[id]/edit.tsx
+++ b/app/routes/books/[id]/edit.tsx
@@ -33,12 +33,7 @@ export default createRoute(async (c) => {
               href={`/books/${id}`}
               class="text-sm font-bold text-zinc-500 hover:text-blue-600 transition-colors inline-flex items-center"
             >
-              <svg
-                class="w-4 h-4 mr-1"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
+              <svg class="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path
                   stroke-linecap="round"
                   stroke-linejoin="round"
@@ -52,13 +47,21 @@ export default createRoute(async (c) => {
           <h1 class="text-3xl font-bold text-zinc-900 tracking-tight">書籍情報を編集</h1>
         </div>
 
-        <form id="edit-form" class="bg-white rounded-2xl p-8 shadow-sm ring-1 ring-zinc-100 space-y-8">
+        <form
+          id="edit-form"
+          class="bg-white rounded-2xl p-8 shadow-sm ring-1 ring-zinc-100 space-y-8"
+        >
           <div class="space-y-6">
             <div>
               <Label for="title" required class="mb-2 block text-sm font-bold text-zinc-700">
                 タイトル
               </Label>
-              <Input name="title" required value={book.title} class="rounded-xl border-zinc-200 bg-zinc-50 focus:bg-white transition-colors" />
+              <Input
+                name="title"
+                required
+                value={book.title}
+                class="rounded-xl border-zinc-200 bg-zinc-50 focus:bg-white transition-colors"
+              />
             </div>
 
             <div>
@@ -76,22 +79,43 @@ export default createRoute(async (c) => {
 
             <div class="grid grid-cols-2 gap-6">
               <div>
-                <Label for="publisher" class="mb-2 block text-sm font-bold text-zinc-700">出版社</Label>
-                <Input name="publisher" value={book.publisher || ""} class="rounded-xl border-zinc-200 bg-zinc-50 focus:bg-white transition-colors" />
+                <Label for="publisher" class="mb-2 block text-sm font-bold text-zinc-700">
+                  出版社
+                </Label>
+                <Input
+                  name="publisher"
+                  value={book.publisher || ""}
+                  class="rounded-xl border-zinc-200 bg-zinc-50 focus:bg-white transition-colors"
+                />
               </div>
               <div>
-                <Label for="isbn" class="mb-2 block text-sm font-bold text-zinc-700">ISBN</Label>
-                <Input name="isbn" value={book.isbn || ""} class="rounded-xl border-zinc-200 bg-zinc-50 focus:bg-white transition-colors" />
+                <Label for="isbn" class="mb-2 block text-sm font-bold text-zinc-700">
+                  ISBN
+                </Label>
+                <Input
+                  name="isbn"
+                  value={book.isbn || ""}
+                  class="rounded-xl border-zinc-200 bg-zinc-50 focus:bg-white transition-colors"
+                />
               </div>
             </div>
 
             <div class="grid grid-cols-2 gap-6">
               <div>
-                <Label for="pageCount" class="mb-2 block text-sm font-bold text-zinc-700">ページ数</Label>
-                <Input type="number" name="pageCount" value={book.page_count} class="rounded-xl border-zinc-200 bg-zinc-50 focus:bg-white transition-colors" />
+                <Label for="pageCount" class="mb-2 block text-sm font-bold text-zinc-700">
+                  ページ数
+                </Label>
+                <Input
+                  type="number"
+                  name="pageCount"
+                  value={book.page_count}
+                  class="rounded-xl border-zinc-200 bg-zinc-50 focus:bg-white transition-colors"
+                />
               </div>
               <div>
-                <Label for="publishedDate" class="mb-2 block text-sm font-bold text-zinc-700">出版日</Label>
+                <Label for="publishedDate" class="mb-2 block text-sm font-bold text-zinc-700">
+                  出版日
+                </Label>
                 <Input
                   name="publishedDate"
                   value={book.published_date || ""}
@@ -102,7 +126,9 @@ export default createRoute(async (c) => {
             </div>
 
             <div>
-              <Label for="description" class="mb-2 block text-sm font-bold text-zinc-700">概要</Label>
+              <Label for="description" class="mb-2 block text-sm font-bold text-zinc-700">
+                概要
+              </Label>
               <Textarea
                 name="description"
                 value={book.description || ""}
@@ -112,7 +138,9 @@ export default createRoute(async (c) => {
             </div>
 
             <div>
-              <Label for="thumbnailUrl" class="mb-2 block text-sm font-bold text-zinc-700">表紙画像URL</Label>
+              <Label for="thumbnailUrl" class="mb-2 block text-sm font-bold text-zinc-700">
+                表紙画像URL
+              </Label>
               <Input
                 name="thumbnailUrl"
                 value={book.thumbnail_url || ""}
@@ -173,6 +201,6 @@ export default createRoute(async (c) => {
           </div>
         </form>
       </div>
-    </Layout>
+    </Layout>,
   );
 });

--- a/app/routes/books/[id]/index.tsx
+++ b/app/routes/books/[id]/index.tsx
@@ -1,10 +1,9 @@
 import { createRoute } from "honox/factory";
 import { requirePageAuth, getSidebarExpanded } from "../../../lib/page-auth";
 import { Layout } from "../../../components/layout/Layout";
-import { StatusBadge, Badge } from "../../../components/ui/Badge";
 import { BookCover } from "../../../components/book/BookCover";
 import { Button } from "../../../components/ui/Button";
-import { bookRepo, bookTagRepo } from "../../../server/db/repositories";
+import { bookRepo } from "../../../server/db/repositories";
 import ProgressSlider from "../../../islands/ProgressSlider";
 import StatusToggle from "../../../islands/StatusToggle";
 import MemoEditor from "../../../islands/MemoEditor";
@@ -26,7 +25,6 @@ export default createRoute(async (c) => {
     return c.redirect("/books");
   }
 
-  const tags = await bookTagRepo.findTagsByBookId(c.env.DB, id);
   const authors = JSON.parse(book.authors) as string[];
 
   return c.render(
@@ -96,12 +94,7 @@ export default createRoute(async (c) => {
                   class="flex items-center justify-center w-full px-4 py-3 text-sm font-bold text-white bg-[#bf0000] rounded-xl hover:bg-[#a00000] transition-colors shadow-sm"
                 >
                   <span class="mr-2">楽天ブックスで見る</span>
-                  <svg
-                    class="w-4 h-4"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
+                  <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path
                       stroke-linecap="round"
                       stroke-linejoin="round"
@@ -126,8 +119,7 @@ export default createRoute(async (c) => {
                   <p class="font-medium text-zinc-800">{authors.join(", ")}</p>
                   {book.publisher && (
                     <p class="text-sm text-zinc-500">
-                      {book.publisher} <span class="mx-1">・</span>{" "}
-                      {book.published_date}
+                      {book.publisher} <span class="mx-1">・</span> {book.published_date}
                     </p>
                   )}
                 </div>
@@ -169,9 +161,7 @@ export default createRoute(async (c) => {
                       <dt class="text-zinc-400 mb-1 font-bold text-xs uppercase tracking-wider">
                         ページ数
                       </dt>
-                      <dd class="font-mono text-zinc-900">
-                        {book.page_count}ページ
-                      </dd>
+                      <dd class="font-mono text-zinc-900">{book.page_count}ページ</dd>
                     </div>
                   )}
                 </dl>
@@ -188,6 +178,6 @@ export default createRoute(async (c) => {
           </div>
         </div>
       </div>
-    </Layout>
+    </Layout>,
   );
 });

--- a/app/routes/books/index.tsx
+++ b/app/routes/books/index.tsx
@@ -16,12 +16,7 @@ export default createRoute(async (c) => {
 
   const search = c.req.query("search");
   const initialTab = c.req.query("status") as BookStatus | undefined;
-  const sortBy = c.req.query("sort") as
-    | "title"
-    | "created"
-    | "updated"
-    | "progress"
-    | undefined;
+  const sortBy = c.req.query("sort") as "title" | "created" | "updated" | "progress" | undefined;
 
   const { books, total } = await bookRepo.findByUserId(c.env.DB, user.id, {
     search,
@@ -47,9 +42,7 @@ export default createRoute(async (c) => {
       <div class="space-y-8">
         <div class="flex flex-col md:flex-row md:items-end justify-between gap-6 pb-2">
           <div>
-            <h1 class="text-3xl font-bold text-zinc-900 mb-2 tracking-tight">
-              自分の本棚
-            </h1>
+            <h1 class="text-3xl font-bold text-zinc-900 mb-2 tracking-tight">自分の本棚</h1>
             <p class="text-zinc-500 font-medium">全 {total} 冊</p>
           </div>
           <a
@@ -108,12 +101,8 @@ export default createRoute(async (c) => {
           </Button>
         </form>
 
-        <BooksStatusTabs
-          books={formatBooks(books)}
-          total={total}
-          initialTab={initialTab}
-        />
+        <BooksStatusTabs books={formatBooks(books)} total={total} initialTab={initialTab} />
       </div>
-    </Layout>
+    </Layout>,
   );
 });

--- a/app/routes/books/new.tsx
+++ b/app/routes/books/new.tsx
@@ -28,6 +28,6 @@ export default createRoute(async (c) => {
           </div>
         </section>
       </div>
-    </Layout>
+    </Layout>,
   );
 });

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -55,14 +55,8 @@ export default createRoute(async (c) => {
           <nav class="flex items-center justify-between w-full max-w-6xl mx-auto bg-white/80 backdrop-blur-xl border border-zinc-200/60 rounded-full px-4 sm:px-6 py-3 sm:py-3.5 shadow-lg shadow-zinc-900/5">
             {/* Logo */}
             <div class="flex items-center gap-2.5">
-              <img
-                src="/favicon128.ico"
-                alt="gidoku"
-                class="w-8 h-8 rounded-lg"
-              />
-              <span class="text-xl font-bold tracking-tight text-zinc-900">
-                gidoku
-              </span>
+              <img src="/favicon128.ico" alt="gidoku" class="w-8 h-8 rounded-lg" />
+              <span class="text-xl font-bold tracking-tight text-zinc-900">gidoku</span>
             </div>
 
             {/* Navigation */}
@@ -157,25 +151,17 @@ export default createRoute(async (c) => {
   // ログイン済みの場合はダッシュボード
   const stats = await bookRepo.getStats(c.env.DB, user.id);
 
-  const { books: readingBooks } = await bookRepo.findByUserId(
-    c.env.DB,
-    user.id,
-    {
-      status: "reading",
-      limit: 6,
-      offset: 0,
-    },
-  );
+  const { books: readingBooks } = await bookRepo.findByUserId(c.env.DB, user.id, {
+    status: "reading",
+    limit: 6,
+    offset: 0,
+  });
 
-  const { books: recentBooks } = await bookRepo.findByUserId(
-    c.env.DB,
-    user.id,
-    {
-      sortBy: "updated",
-      limit: 6,
-      offset: 0,
-    },
-  );
+  const { books: recentBooks } = await bookRepo.findByUserId(c.env.DB, user.id, {
+    sortBy: "updated",
+    limit: 6,
+    offset: 0,
+  });
 
   const formatBooks = (books: Book[]) =>
     books.map((book) => ({
@@ -209,9 +195,7 @@ export default createRoute(async (c) => {
         {formattedReadingBooks.length > 0 && (
           <section>
             <div class="flex items-center justify-between mb-4 sm:mb-6">
-              <h2 class="text-lg sm:text-xl font-bold text-zinc-900">
-                読んでいる本
-              </h2>
+              <h2 class="text-lg sm:text-xl font-bold text-zinc-900">読んでいる本</h2>
               <a
                 href="/books?status=reading"
                 class="text-sm font-medium text-blue-600 hover:text-blue-700 transition-colors"
@@ -226,9 +210,7 @@ export default createRoute(async (c) => {
 
         <section>
           <div class="flex items-center justify-between mb-4 sm:mb-6">
-            <h2 class="text-lg sm:text-xl font-bold text-zinc-900">
-              最近の読書
-            </h2>
+            <h2 class="text-lg sm:text-xl font-bold text-zinc-900">最近の読書</h2>
             <a
               href="/books"
               class="text-sm font-medium text-blue-600 hover:text-blue-700 transition-colors"
@@ -278,9 +260,7 @@ export default createRoute(async (c) => {
                     />
                   </svg>
                 </div>
-                <p class="text-zinc-500 mb-6 font-medium">
-                  読書記録をはじめましょう
-                </p>
+                <p class="text-zinc-500 mb-6 font-medium">読書記録をはじめましょう</p>
                 <a
                   href="/books/new"
                   class="inline-flex items-center justify-center px-6 py-2.5 text-sm font-bold text-white bg-zinc-900 hover:bg-zinc-800 transition-colors shadow-sm rounded-full"

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -52,20 +52,14 @@ export default createRoute(async (c) => {
         <div class="flex flex-col justify-between w-full lg:w-1/2 px-8 sm:px-12 lg:px-16 xl:px-20 py-12 bg-white relative z-10">
           {/* Logo */}
           <div class="flex items-center">
-            <span class="text-3xl font-bold tracking-tight text-zinc-900">
-              gidoku
-            </span>
+            <span class="text-3xl font-bold tracking-tight text-zinc-900">gidoku</span>
           </div>
 
           {/* Form Content */}
           <div class="w-full max-w-md mx-auto space-y-8">
             <div class="space-y-3">
-              <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-zinc-900">
-                Welcome.
-              </h1>
-              <p class="text-lg text-zinc-500">
-                技術書の読書記録を管理しよう！
-              </p>
+              <h1 class="text-4xl md:text-5xl font-bold tracking-tight text-zinc-900">Welcome.</h1>
+              <p class="text-lg text-zinc-500">技術書の読書記録を管理しよう！</p>
             </div>
 
             {error && (
@@ -104,11 +98,7 @@ export default createRoute(async (c) => {
                 href="/api/auth/github"
                 class="flex items-center justify-center gap-3 w-full px-5 py-3.5 bg-zinc-900 text-white hover:bg-zinc-800 transition-all duration-200 rounded-xl font-medium shadow-md hover:shadow-lg"
               >
-                <svg
-                  class="w-5 h-5 shrink-0"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
+                <svg class="w-5 h-5 shrink-0" viewBox="0 0 24 24" fill="currentColor">
                   <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
                 </svg>
                 <span class="text-sm font-medium">GitHubで続ける</span>
@@ -117,9 +107,7 @@ export default createRoute(async (c) => {
           </div>
 
           {/* Footer */}
-          <div class="text-center text-xs text-zinc-400 font-medium">
-            &copy; 2025 gidoku.com
-          </div>
+          <div class="text-center text-xs text-zinc-400 font-medium">&copy; 2025 gidoku.com</div>
         </div>
 
         {/* Right Side */}
@@ -148,37 +136,19 @@ export default createRoute(async (c) => {
                   style={{ filter: "drop-shadow(0 20px 40px rgba(0,0,0,0.6))" }}
                 >
                   <defs>
-                    <linearGradient
-                      id="coverGrad"
-                      x1="0%"
-                      y1="0%"
-                      x2="100%"
-                      y2="0%"
-                    >
+                    <linearGradient id="coverGrad" x1="0%" y1="0%" x2="100%" y2="0%">
                       <stop offset="0%" stop-color="#18181b" />
                       <stop offset="50%" stop-color="#27272a" />
                       <stop offset="100%" stop-color="#18181b" />
                     </linearGradient>
 
-                    <linearGradient
-                      id="pageGradLeft"
-                      x1="0%"
-                      y1="0%"
-                      x2="100%"
-                      y2="0%"
-                    >
+                    <linearGradient id="pageGradLeft" x1="0%" y1="0%" x2="100%" y2="0%">
                       <stop offset="0%" stop-color="#e4e4e7" />
                       <stop offset="90%" stop-color="#a1a1aa" />
                       <stop offset="100%" stop-color="#71717a" />
                     </linearGradient>
 
-                    <linearGradient
-                      id="pageGradRight"
-                      x1="0%"
-                      y1="0%"
-                      x2="100%"
-                      y2="0%"
-                    >
+                    <linearGradient id="pageGradRight" x1="0%" y1="0%" x2="100%" y2="0%">
                       <stop offset="0%" stop-color="#71717a" />
                       <stop offset="10%" stop-color="#a1a1aa" />
                       <stop offset="100%" stop-color="#e4e4e7" />
@@ -217,43 +187,13 @@ export default createRoute(async (c) => {
 
                   {/* Texture Lines */}
                   <g opacity="0.1">
-                    <path
-                      d="M55 50 Q130 40, 200 55"
-                      stroke="#000"
-                      stroke-width="1"
-                      fill="none"
-                    />
-                    <path
-                      d="M55 65 Q130 55, 200 70"
-                      stroke="#000"
-                      stroke-width="1"
-                      fill="none"
-                    />
-                    <path
-                      d="M55 80 Q130 70, 200 85"
-                      stroke="#000"
-                      stroke-width="1"
-                      fill="none"
-                    />
+                    <path d="M55 50 Q130 40, 200 55" stroke="#000" stroke-width="1" fill="none" />
+                    <path d="M55 65 Q130 55, 200 70" stroke="#000" stroke-width="1" fill="none" />
+                    <path d="M55 80 Q130 70, 200 85" stroke="#000" stroke-width="1" fill="none" />
 
-                    <path
-                      d="M240 55 Q310 40, 385 50"
-                      stroke="#000"
-                      stroke-width="1"
-                      fill="none"
-                    />
-                    <path
-                      d="M240 70 Q310 55, 385 65"
-                      stroke="#000"
-                      stroke-width="1"
-                      fill="none"
-                    />
-                    <path
-                      d="M240 85 Q310 70, 385 80"
-                      stroke="#000"
-                      stroke-width="1"
-                      fill="none"
-                    />
+                    <path d="M240 55 Q310 40, 385 50" stroke="#000" stroke-width="1" fill="none" />
+                    <path d="M240 70 Q310 55, 385 65" stroke="#000" stroke-width="1" fill="none" />
+                    <path d="M240 85 Q310 70, 385 80" stroke="#000" stroke-width="1" fill="none" />
                   </g>
                 </svg>
               </div>
@@ -261,6 +201,6 @@ export default createRoute(async (c) => {
           </div>
         </div>
       </div>
-    </>
+    </>,
   );
 });

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -18,9 +18,7 @@ export default createRoute(async (c) => {
       <div class="space-y-12">
         {/* Header */}
         <div class="border-b border-zinc-100 pb-8">
-          <h1 class="text-3xl font-bold tracking-tight text-zinc-900 mb-2">
-            設定
-          </h1>
+          <h1 class="text-3xl font-bold tracking-tight text-zinc-900 mb-2">設定</h1>
           <p class="text-zinc-500">プロフィールとアカウント設定の管理</p>
         </div>
 
@@ -50,15 +48,15 @@ export default createRoute(async (c) => {
         <section class="grid md:grid-cols-[240px_1fr] gap-8 md:gap-12 items-start">
           <div>
             <h2 class="text-lg font-bold text-zinc-900 mb-2">アカウント</h2>
-            <p class="text-sm text-zinc-500 leading-relaxed">
-              アカウントの基本情報と連携設定。
-            </p>
+            <p class="text-sm text-zinc-500 leading-relaxed">アカウントの基本情報と連携設定。</p>
           </div>
 
           <div class="bg-white rounded-2xl p-8 shadow-sm ring-1 ring-zinc-100 space-y-8">
             <div class="grid gap-6">
               <div>
-                <Label for="email" class="mb-2 block text-sm font-bold text-zinc-700">メールアドレス</Label>
+                <Label for="email" class="mb-2 block text-sm font-bold text-zinc-700">
+                  メールアドレス
+                </Label>
                 <Input
                   name="email"
                   value={user.email}
@@ -68,15 +66,13 @@ export default createRoute(async (c) => {
               </div>
 
               <div>
-                <Label for="provider" class="mb-2 block text-sm font-bold text-zinc-700">連携アカウント</Label>
+                <Label for="provider" class="mb-2 block text-sm font-bold text-zinc-700">
+                  連携アカウント
+                </Label>
                 <div class="flex items-center gap-3 p-4 border border-zinc-200 rounded-xl bg-zinc-50/50">
                   {user.provider === "github" ? (
                     // GitHub icon
-                    <svg
-                      class="w-5 h-5"
-                      viewBox="0 0 24 24"
-                      fill="currentColor"
-                    >
+                    <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
                       <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
                     </svg>
                   ) : (
@@ -164,6 +160,6 @@ export default createRoute(async (c) => {
           </div>
         </section>
       </div>
-    </Layout>
+    </Layout>,
   );
 });

--- a/app/routes/user/[username].tsx
+++ b/app/routes/user/[username].tsx
@@ -51,12 +51,7 @@ const NotFoundPage: FC<NotFoundPageProps> = ({ username, currentUser }) => (
     <div class="flex items-center justify-center min-h-[60vh]">
       <div class="text-center max-w-md mx-auto">
         <div class="w-16 h-16 bg-zinc-100 rounded-full flex items-center justify-center mx-auto mb-6">
-          <svg
-            class="w-8 h-8 text-zinc-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
+          <svg class="w-8 h-8 text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <title>ユーザーアイコン</title>
             <path
               stroke-linecap="round"
@@ -130,22 +125,32 @@ export default createRoute(async (c) => {
 
   const currentUser = await getPageUser(c);
 
-  const profileUser = await userRepo
-    .findByUsername(c.env.DB, username)
-    .catch(() => null);
+  const profileUser = await userRepo.findByUsername(c.env.DB, username).catch(() => null);
 
   if (!profileUser) {
-    return c.render(
-      <NotFoundPage username={username} currentUser={currentUser} />
-    );
+    return c.render(<NotFoundPage username={username} currentUser={currentUser} />);
   }
 
-  const [stats, { books: rawReadingBooks }, { books: rawUnreadBooks }, { books: rawCompletedBooks }] =
-    await Promise.all([
+  const [
+    stats,
+    { books: rawReadingBooks },
+    { books: rawUnreadBooks },
+    { books: rawCompletedBooks },
+  ] = await Promise.all([
     bookRepo.getStats(c.env.DB, profileUser.id),
     bookRepo.findByUserId(c.env.DB, profileUser.id, { status: "reading", limit: 12, offset: 0 }),
-    bookRepo.findByUserId(c.env.DB, profileUser.id, { status: "unread", sortBy: "updated", limit: 24, offset: 0 }),
-    bookRepo.findByUserId(c.env.DB, profileUser.id, { status: "completed", sortBy: "updated", limit: 24, offset: 0 }),
+    bookRepo.findByUserId(c.env.DB, profileUser.id, {
+      status: "unread",
+      sortBy: "updated",
+      limit: 24,
+      offset: 0,
+    }),
+    bookRepo.findByUserId(c.env.DB, profileUser.id, {
+      status: "completed",
+      sortBy: "updated",
+      limit: 24,
+      offset: 0,
+    }),
   ]);
 
   return c.render(
@@ -156,6 +161,6 @@ export default createRoute(async (c) => {
       unreadBooks={rawUnreadBooks.map(toBookListItem)}
       completedBooks={rawCompletedBooks.map(toBookListItem)}
       currentUser={currentUser}
-    />
+    />,
   );
 });

--- a/app/routes/user/_middleware.ts
+++ b/app/routes/user/_middleware.ts
@@ -2,9 +2,6 @@ import { createRoute } from "honox/factory";
 
 // 公開プロフィールページのキャッシュ設定(ブラウザは1分間キャッシュ, CDNは5分間キャッシュ)
 export default createRoute((c, next) => {
-  c.header(
-    "Cache-Control",
-    "public, max-age=60, s-maxage=300, stale-while-revalidate=300"
-  );
+  c.header("Cache-Control", "public, max-age=60, s-maxage=300, stale-while-revalidate=300");
   return next();
 });

--- a/app/server.ts
+++ b/app/server.ts
@@ -15,18 +15,14 @@ app.use(
       styleSrc: ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
       fontSrc: ["'self'", "https://fonts.gstatic.com"],
       imgSrc: ["'self'", "data:", "https:"],
-      connectSrc: [
-        "'self'",
-        "https://api.github.com",
-        "https://accounts.google.com",
-      ],
+      connectSrc: ["'self'", "https://api.github.com", "https://accounts.google.com"],
       baseUri: ["'self'"],
       formAction: ["'self'"],
       frameAncestors: ["'none'"],
       objectSrc: ["'none'"],
       upgradeInsecureRequests: [],
     },
-  })
+  }),
 );
 
 // CSRF保護（Origin/Sec-Fetch-Site検証）
@@ -39,7 +35,7 @@ app.use(
       const allowedOrigins = [appUrl, "http://localhost:5173"];
       return allowedOrigins.includes(origin);
     },
-  })
+  }),
 );
 
 app.route("/api", api);

--- a/app/server/api/auth.test.ts
+++ b/app/server/api/auth.test.ts
@@ -1,78 +1,89 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { env } from 'cloudflare:test'
-import api from './index'
-import { createTestSession, createTestUser, cleanupDatabase } from '../../test/helpers'
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import api from "./index";
+import { createTestSession, createTestUser, cleanupDatabase } from "../../test/helpers";
 
-describe('Auth API Integration', () => {
+describe("Auth API Integration", () => {
   beforeEach(async () => {
-    await cleanupDatabase(env.DB)
-  })
+    await cleanupDatabase(env.DB);
+  });
 
-  it('should redirect and store oauth state', async () => {
-    const res = await api.request('/auth/github', {}, env)
+  it("should redirect and store oauth state", async () => {
+    const res = await api.request("/auth/github", {}, env);
 
-    expect([302, 307]).toContain(res.status)
-    const location = res.headers.get('Location')
-    expect(location).toBeTruthy()
+    expect([302, 307]).toContain(res.status);
+    const location = res.headers.get("Location");
+    expect(location).toBeTruthy();
     if (!location) {
-      throw new Error('Missing redirect location')
+      throw new Error("Missing redirect location");
     }
 
-    const url = new URL(location)
-    const state = url.searchParams.get('state')
-    expect(state).toBeTruthy()
+    const url = new URL(location);
+    const state = url.searchParams.get("state");
+    expect(state).toBeTruthy();
 
-    const storedProvider = await env.KV.get(`oauth_state:${state}`)
-    expect(storedProvider).toBe('github')
-  })
+    const storedProvider = await env.KV.get(`oauth_state:${state}`);
+    expect(storedProvider).toBe("github");
+  });
 
-  it('should return 400 for invalid provider', async () => {
-    const res = await api.request('/auth/invalid', {}, env)
-    expect(res.status).toBe(400)
-  })
+  it("should return 400 for invalid provider", async () => {
+    const res = await api.request("/auth/invalid", {}, env);
+    expect(res.status).toBe(400);
+  });
 
-  it('should reject callback with invalid state', async () => {
-    const state = 'state_mismatch'
-    await env.KV.put(`oauth_state:${state}`, 'github')
+  it("should reject callback with invalid state", async () => {
+    const state = "state_mismatch";
+    await env.KV.put(`oauth_state:${state}`, "github");
 
-    const res = await api.request(`/auth/google/callback?code=123&state=${state}`, {}, env)
-    expect(res.status).toBe(400)
-    const body = await res.json() as { success: boolean; error: { code: string } }
-    expect(body.success).toBe(false)
-    expect(body.error.code).toBe('INVALID_STATE')
-  })
+    const res = await api.request(`/auth/google/callback?code=123&state=${state}`, {}, env);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { success: boolean; error: { code: string } };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("INVALID_STATE");
+  });
 
-  it('should return session info for authenticated user', async () => {
-    const user = await createTestUser(env.DB)
-    const sessionId = await createTestSession(env.KV, user.id)
+  it("should return session info for authenticated user", async () => {
+    const user = await createTestUser(env.DB);
+    const sessionId = await createTestSession(env.KV, user.id);
 
-    const res = await api.request('/auth/session', {
-      headers: { Cookie: `session_id=${sessionId}` },
-    }, env)
+    const res = await api.request(
+      "/auth/session",
+      {
+        headers: { Cookie: `session_id=${sessionId}` },
+      },
+      env,
+    );
 
-    expect(res.status).toBe(200)
-    const body = await res.json() as { success: boolean; data: { authenticated: boolean; user: { id: string } } }
-    expect(body.success).toBe(true)
-    expect(body.data.authenticated).toBe(true)
-    expect(body.data.user.id).toBe(user.id)
-  })
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { authenticated: boolean; user: { id: string } };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.authenticated).toBe(true);
+    expect(body.data.user.id).toBe(user.id);
+  });
 
-  it('should delete session on logout', async () => {
-    const user = await createTestUser(env.DB)
-    const sessionId = await createTestSession(env.KV, user.id)
+  it("should delete session on logout", async () => {
+    const user = await createTestUser(env.DB);
+    const sessionId = await createTestSession(env.KV, user.id);
 
-    const res = await api.request('/auth/logout', {
-      method: 'POST',
-      headers: { Cookie: `session_id=${sessionId}` },
-    }, env)
+    const res = await api.request(
+      "/auth/logout",
+      {
+        method: "POST",
+        headers: { Cookie: `session_id=${sessionId}` },
+      },
+      env,
+    );
 
-    expect(res.status).toBe(200)
-    const session = await env.KV.get(`session:${sessionId}`)
-    expect(session).toBeNull()
-  })
+    expect(res.status).toBe(200);
+    const session = await env.KV.get(`session:${sessionId}`);
+    expect(session).toBeNull();
+  });
 
-  it('should return 401 when accessing session without cookie', async () => {
-    const res = await api.request('/auth/session', {}, env)
-    expect(res.status).toBe(401)
-  })
-})
+  it("should return 401 when accessing session without cookie", async () => {
+    const res = await api.request("/auth/session", {}, env);
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/server/api/auth.ts
+++ b/app/server/api/auth.ts
@@ -6,11 +6,7 @@ import { authMiddleware } from "../lib/auth";
 import { validator, getValidated } from "../lib/validator";
 import { oauthProviderParamSchema, oauthCallbackSchema } from "./schemas";
 import type { OAuthProvider, OAuthCallbackInput } from "./schemas/auth";
-import {
-  deleteSession,
-  regenerateSession,
-  SESSION_COOKIE_OPTIONS,
-} from "../lib/session";
+import { deleteSession, regenerateSession, SESSION_COOKIE_OPTIONS } from "../lib/session";
 import { toUserResponse } from "../lib/mapper";
 import { successResponse, errorResponse } from "../lib/response";
 import * as oauthService from "../services/oauth";
@@ -94,21 +90,13 @@ app.get(
 
     try {
       // アクセストークン取得
-      const accessToken = await oauthService.getAccessToken(
-        provider,
-        code,
-        c.env
-      );
+      const accessToken = await oauthService.getAccessToken(provider, code, c.env);
 
       // ユーザー情報取得
       const oauthUser = await oauthService.getUser(provider, accessToken);
 
       // 既存ユーザー検索
-      let user = await userRepo.findByProvider(
-        c.env.DB,
-        provider,
-        oauthUser.providerId
-      );
+      let user = await userRepo.findByProvider(c.env.DB, provider, oauthUser.providerId);
 
       if (!user) {
         // 新規ユーザー作成
@@ -130,11 +118,7 @@ app.get(
       // セッションを再生成
       // 既存のセッションがあれば削除して新しいセッションを作成
       const oldSessionId = getCookie(c, "session_id");
-      const sessionId = await regenerateSession(
-        c.env.KV,
-        oldSessionId,
-        user.id
-      );
+      const sessionId = await regenerateSession(c.env.KV, oldSessionId, user.id);
 
       // Cookie設定
       setCookie(c, "session_id", sessionId, SESSION_COOKIE_OPTIONS);
@@ -145,16 +129,13 @@ app.get(
       console.error("OAuth error:", error);
       return c.redirect(`${c.env.APP_URL}/login?error=auth_failed`);
     }
-  }
+  },
 );
 
 /**
  * ユニークなユーザー名を生成
  */
-async function generateUniqueUsername(
-  db: D1Database,
-  baseUsername: string
-): Promise<string> {
+async function generateUniqueUsername(db: D1Database, baseUsername: string): Promise<string> {
   // 無効な文字を除去
   let username = baseUsername.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 20);
 

--- a/app/server/api/books.test.ts
+++ b/app/server/api/books.test.ts
@@ -1,293 +1,353 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { env } from 'cloudflare:test'
-import api from './index'
-import { createTestUser, createTestSession, createTestBook } from '../../test/helpers'
-import type { SuccessResponse, PaginatedResponse } from '../lib/response'
-import type { BookResponse } from '../../types/database'
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import api from "./index";
+import { createTestUser, createTestSession, createTestBook } from "../../test/helpers";
+import type { SuccessResponse, PaginatedResponse } from "../lib/response";
+import type { BookResponse } from "../../types/database";
 
-describe('Books API Integration', () => {
-  let userId: string
-  let sessionId: string
+describe("Books API Integration", () => {
+  let userId: string;
+  let sessionId: string;
 
   beforeEach(async () => {
-    await env.DB.prepare('DELETE FROM book_tags').run()
-    await env.DB.prepare('DELETE FROM tags').run()
-    await env.DB.prepare('DELETE FROM books').run()
-    await env.DB.prepare('DELETE FROM users').run()
+    await env.DB.prepare("DELETE FROM book_tags").run();
+    await env.DB.prepare("DELETE FROM tags").run();
+    await env.DB.prepare("DELETE FROM books").run();
+    await env.DB.prepare("DELETE FROM users").run();
 
-    const user = await createTestUser(env.DB)
-    userId = user.id
-    sessionId = await createTestSession(env.KV, userId)
-  })
+    const user = await createTestUser(env.DB);
+    userId = user.id;
+    sessionId = await createTestSession(env.KV, userId);
+  });
 
-  describe('Authentication', () => {
-    it('should return 401 without session cookie', async () => {
-      const res = await api.request('/books', {}, env)
-      expect(res.status).toBe(401)
-    })
+  describe("Authentication", () => {
+    it("should return 401 without session cookie", async () => {
+      const res = await api.request("/books", {}, env);
+      expect(res.status).toBe(401);
+    });
 
-    it('should return 200 with valid session cookie', async () => {
-      const res = await api.request('/books', {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
-      expect(res.status).toBe(200)
-    })
-  })
-
-  describe('GET /books', () => {
-    it('should return empty list when no books', async () => {
-      const res = await api.request('/books', {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
-
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<PaginatedResponse<BookResponse>>
-      expect(body.success).toBe(true)
-      expect(body.data.items).toEqual([])
-      expect(body.data.total).toBe(0)
-    })
-
-    it('should return books for authenticated user', async () => {
-      await createTestBook(env.DB, userId, { title: 'Book 1' })
-      await createTestBook(env.DB, userId, { title: 'Book 2' })
-
-      const res = await api.request('/books', {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
-
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<PaginatedResponse<BookResponse>>
-      expect(body.data.items).toHaveLength(2)
-      expect(body.data.total).toBe(2)
-    })
-  })
-
-  describe('GET /books filters', () => {
-    it('should filter by status', async () => {
-      await createTestBook(env.DB, userId, { status: 'reading' })
-      await createTestBook(env.DB, userId, { status: 'completed' })
-
-      const res = await api.request('/books?status=reading', {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
-
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<PaginatedResponse<BookResponse>>
-      expect(body.data.items).toHaveLength(1)
-      expect(body.data.items[0].status).toBe('reading')
-    })
-
-    it('should filter by search term', async () => {
-      await createTestBook(env.DB, userId, { title: 'JavaScript Guide' })
-      await createTestBook(env.DB, userId, { title: 'Python Guide' })
-
-      const res = await api.request('/books?search=JavaScript', {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
-
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<PaginatedResponse<BookResponse>>
-      expect(body.data.items).toHaveLength(1)
-      expect(body.data.items[0].title).toBe('JavaScript Guide')
-    })
-
-    it('should sort by title ascending', async () => {
-      await createTestBook(env.DB, userId, { title: 'Zeta Book' })
-      await createTestBook(env.DB, userId, { title: 'Alpha Book' })
-
-      const res = await api.request('/books?sortBy=title', {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
-
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<PaginatedResponse<BookResponse>>
-      expect(body.data.items[0].title).toBe('Alpha Book')
-    })
-
-    it('should support pagination', async () => {
-      await createTestBook(env.DB, userId, { title: 'Book 1' })
-      await createTestBook(env.DB, userId, { title: 'Book 2' })
-      await createTestBook(env.DB, userId, { title: 'Book 3' })
-
-      const res = await api.request('/books?limit=1&offset=1', {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
-
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<PaginatedResponse<BookResponse>>
-      expect(body.data.items).toHaveLength(1)
-      expect(body.data.total).toBe(3)
-      expect(body.data.limit).toBe(1)
-      expect(body.data.offset).toBe(1)
-      expect(body.data.hasMore).toBe(true)
-    })
-  })
-
-  describe('POST /books', () => {
-    it('should create a new book', async () => {
-      const res = await api.request('/books', {
-        method: 'POST',
-        headers: {
-          Cookie: `session_id=${sessionId}`,
-          'Content-Type': 'application/json',
+    it("should return 200 with valid session cookie", async () => {
+      const res = await api.request(
+        "/books",
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
         },
-        body: JSON.stringify({
-          title: 'New Test Book',
-          authors: ['Test Author'],
-          pageCount: 250,
-        }),
-      }, env)
+        env,
+      );
+      expect(res.status).toBe(200);
+    });
+  });
 
-      expect(res.status).toBe(201)
-      const body = await res.json() as SuccessResponse<BookResponse>
-      expect(body.success).toBe(true)
-      expect(body.data.title).toBe('New Test Book')
-    })
-  })
-
-  describe('PUT /books/:id', () => {
-    it('should update book fields', async () => {
-      const book = await createTestBook(env.DB, userId, { title: 'Old Title' })
-
-      const res = await api.request(`/books/${book.id}`, {
-        method: 'PUT',
-        headers: {
-          Cookie: `session_id=${sessionId}`,
-          'Content-Type': 'application/json',
+  describe("GET /books", () => {
+    it("should return empty list when no books", async () => {
+      const res = await api.request(
+        "/books",
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
         },
-        body: JSON.stringify({
-          title: 'New Title',
-          status: 'reading',
-          currentPage: 10,
-        }),
-      }, env)
+        env,
+      );
 
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<BookResponse>
-      expect(body.data.title).toBe('New Title')
-      expect(body.data.status).toBe('reading')
-      expect(body.data.currentPage).toBe(10)
-    })
-  })
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      expect(body.success).toBe(true);
+      expect(body.data.items).toEqual([]);
+      expect(body.data.total).toBe(0);
+    });
 
-  describe('GET /books/:id', () => {
-    it('should return a book by id', async () => {
-      const book = await createTestBook(env.DB, userId, { title: 'My Book' })
+    it("should return books for authenticated user", async () => {
+      await createTestBook(env.DB, userId, { title: "Book 1" });
+      await createTestBook(env.DB, userId, { title: "Book 2" });
 
-      const res = await api.request(`/books/${book.id}`, {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
+      const res = await api.request(
+        "/books",
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
 
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<BookResponse>
-      expect(body.data.title).toBe('My Book')
-    })
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      expect(body.data.items).toHaveLength(2);
+      expect(body.data.total).toBe(2);
+    });
+  });
+
+  describe("GET /books filters", () => {
+    it("should filter by status", async () => {
+      await createTestBook(env.DB, userId, { status: "reading" });
+      await createTestBook(env.DB, userId, { status: "completed" });
+
+      const res = await api.request(
+        "/books?status=reading",
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      expect(body.data.items).toHaveLength(1);
+      expect(body.data.items[0].status).toBe("reading");
+    });
+
+    it("should filter by search term", async () => {
+      await createTestBook(env.DB, userId, { title: "JavaScript Guide" });
+      await createTestBook(env.DB, userId, { title: "Python Guide" });
+
+      const res = await api.request(
+        "/books?search=JavaScript",
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      expect(body.data.items).toHaveLength(1);
+      expect(body.data.items[0].title).toBe("JavaScript Guide");
+    });
+
+    it("should sort by title ascending", async () => {
+      await createTestBook(env.DB, userId, { title: "Zeta Book" });
+      await createTestBook(env.DB, userId, { title: "Alpha Book" });
+
+      const res = await api.request(
+        "/books?sortBy=title",
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      expect(body.data.items[0].title).toBe("Alpha Book");
+    });
+
+    it("should support pagination", async () => {
+      await createTestBook(env.DB, userId, { title: "Book 1" });
+      await createTestBook(env.DB, userId, { title: "Book 2" });
+      await createTestBook(env.DB, userId, { title: "Book 3" });
+
+      const res = await api.request(
+        "/books?limit=1&offset=1",
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      expect(body.data.items).toHaveLength(1);
+      expect(body.data.total).toBe(3);
+      expect(body.data.limit).toBe(1);
+      expect(body.data.offset).toBe(1);
+      expect(body.data.hasMore).toBe(true);
+    });
+  });
+
+  describe("POST /books", () => {
+    it("should create a new book", async () => {
+      const res = await api.request(
+        "/books",
+        {
+          method: "POST",
+          headers: {
+            Cookie: `session_id=${sessionId}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            title: "New Test Book",
+            authors: ["Test Author"],
+            pageCount: 250,
+          }),
+        },
+        env,
+      );
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as SuccessResponse<BookResponse>;
+      expect(body.success).toBe(true);
+      expect(body.data.title).toBe("New Test Book");
+    });
+  });
+
+  describe("PUT /books/:id", () => {
+    it("should update book fields", async () => {
+      const book = await createTestBook(env.DB, userId, { title: "Old Title" });
+
+      const res = await api.request(
+        `/books/${book.id}`,
+        {
+          method: "PUT",
+          headers: {
+            Cookie: `session_id=${sessionId}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            title: "New Title",
+            status: "reading",
+            currentPage: 10,
+          }),
+        },
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<BookResponse>;
+      expect(body.data.title).toBe("New Title");
+      expect(body.data.status).toBe("reading");
+      expect(body.data.currentPage).toBe(10);
+    });
+  });
+
+  describe("GET /books/:id", () => {
+    it("should return a book by id", async () => {
+      const book = await createTestBook(env.DB, userId, { title: "My Book" });
+
+      const res = await api.request(
+        `/books/${book.id}`,
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<BookResponse>;
+      expect(body.data.title).toBe("My Book");
+    });
 
     // Note: 404 test is skipped because the current error handler wraps NotFoundError in DatabaseError
     // This would need application code changes to fix
-    it.skip('should return 404 for non-existent book', async () => {
-      const nonExistentId = '00000000-0000-0000-0000-000000000000'
-      const res = await api.request(`/books/${nonExistentId}`, {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
+    it.skip("should return 404 for non-existent book", async () => {
+      const nonExistentId = "00000000-0000-0000-0000-000000000000";
+      const res = await api.request(
+        `/books/${nonExistentId}`,
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
 
-      expect(res.status).toBe(404)
-    })
-  })
+      expect(res.status).toBe(404);
+    });
+  });
 
-  describe('PATCH /books/:id/progress', () => {
-    it('should update book progress and auto-calculate status', async () => {
+  describe("PATCH /books/:id/progress", () => {
+    it("should update book progress and auto-calculate status", async () => {
       const book = await createTestBook(env.DB, userId, {
         pageCount: 300,
         currentPage: 0,
-        status: 'unread',
-      })
+        status: "unread",
+      });
 
-      const res = await api.request(`/books/${book.id}/progress`, {
-        method: 'PATCH',
-        headers: {
-          Cookie: `session_id=${sessionId}`,
-          'Content-Type': 'application/json',
+      const res = await api.request(
+        `/books/${book.id}/progress`,
+        {
+          method: "PATCH",
+          headers: {
+            Cookie: `session_id=${sessionId}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ currentPage: 150 }),
         },
-        body: JSON.stringify({ currentPage: 150 }),
-      }, env)
+        env,
+      );
 
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<BookResponse>
-      expect(body.data.currentPage).toBe(150)
-      expect(body.data.status).toBe('reading')
-    })
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<BookResponse>;
+      expect(body.data.currentPage).toBe(150);
+      expect(body.data.status).toBe("reading");
+    });
 
-    it('should auto-complete when reaching last page', async () => {
+    it("should auto-complete when reaching last page", async () => {
       const book = await createTestBook(env.DB, userId, {
         pageCount: 300,
         currentPage: 0,
-        status: 'unread',
-      })
+        status: "unread",
+      });
 
-      const res = await api.request(`/books/${book.id}/progress`, {
-        method: 'PATCH',
-        headers: {
-          Cookie: `session_id=${sessionId}`,
-          'Content-Type': 'application/json',
+      const res = await api.request(
+        `/books/${book.id}/progress`,
+        {
+          method: "PATCH",
+          headers: {
+            Cookie: `session_id=${sessionId}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ currentPage: 300 }),
         },
-        body: JSON.stringify({ currentPage: 300 }),
-      }, env)
+        env,
+      );
 
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<BookResponse>
-      expect(body.data.status).toBe('completed')
-      expect(body.data.finishedAt).toBeTruthy()
-    })
-  })
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<BookResponse>;
+      expect(body.data.status).toBe("completed");
+      expect(body.data.finishedAt).toBeTruthy();
+    });
+  });
 
-  describe('DELETE /books/:id', () => {
-    it('should delete a book', async () => {
-      const book = await createTestBook(env.DB, userId)
+  describe("DELETE /books/:id", () => {
+    it("should delete a book", async () => {
+      const book = await createTestBook(env.DB, userId);
 
-      const res = await api.request(`/books/${book.id}`, {
-        method: 'DELETE',
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
+      const res = await api.request(
+        `/books/${book.id}`,
+        {
+          method: "DELETE",
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
 
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<{ deleted: boolean }>
-      expect(body.data.deleted).toBe(true)
-    })
-  })
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<{ deleted: boolean }>;
+      expect(body.data.deleted).toBe(true);
+    });
+  });
 
-  describe('GET /books/stats', () => {
-    it('should return aggregated stats', async () => {
-      await createTestBook(env.DB, userId, { status: 'reading' })
-      await createTestBook(env.DB, userId, { status: 'reading' })
-      await createTestBook(env.DB, userId, { status: 'completed' })
-      await createTestBook(env.DB, userId, { status: 'unread' })
+  describe("GET /books/stats", () => {
+    it("should return aggregated stats", async () => {
+      await createTestBook(env.DB, userId, { status: "reading" });
+      await createTestBook(env.DB, userId, { status: "reading" });
+      await createTestBook(env.DB, userId, { status: "completed" });
+      await createTestBook(env.DB, userId, { status: "unread" });
 
-      const res = await api.request('/books/stats', {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
+      const res = await api.request(
+        "/books/stats",
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
 
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<{
-        total: number
-        reading: number
-        completed: number
-        unread: number
-      }>
-      expect(body.data.total).toBe(4)
-      expect(body.data.reading).toBe(2)
-      expect(body.data.completed).toBe(1)
-      expect(body.data.unread).toBe(1)
-    })
-  })
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<{
+        total: number;
+        reading: number;
+        completed: number;
+        unread: number;
+      }>;
+      expect(body.data.total).toBe(4);
+      expect(body.data.reading).toBe(2);
+      expect(body.data.completed).toBe(1);
+      expect(body.data.unread).toBe(1);
+    });
+  });
 
-  describe('Health Check', () => {
-    it('should return health status', async () => {
-      const res = await api.request('/health', {}, env)
+  describe("Health Check", () => {
+    it("should return health status", async () => {
+      const res = await api.request("/health", {}, env);
 
-      expect(res.status).toBe(200)
-      const body = await res.json() as { status: string }
-      expect(body.status).toBe('ok')
-    })
-  })
-})
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string };
+      expect(body.status).toBe("ok");
+    });
+  });
+});

--- a/app/server/api/books.ts
+++ b/app/server/api/books.ts
@@ -43,13 +43,7 @@ app.get("/", validator("query", bookFilterSchema), async (c) => {
   });
 
   const items = books.map(toBookResponse);
-  return paginatedResponse(
-    c,
-    items,
-    total,
-    filter.limit ?? 20,
-    filter.offset ?? 0
-  );
+  return paginatedResponse(c, items, total, filter.limit ?? 20, filter.offset ?? 0);
 });
 
 /**
@@ -115,7 +109,7 @@ app.put(
     const book = await bookRepo.update(c.env.DB, id, userId, updateData);
 
     return successResponse(c, toBookResponse(book));
-  }
+  },
 );
 
 /**
@@ -133,26 +127,17 @@ app.patch(
 
     // 書籍を取得してページ数を検証
     const existingBook = await bookRepo.findById(c.env.DB, id, userId);
-    const validation = bookDomain.validatePageProgress(
-      currentPage,
-      existingBook.page_count
-    );
+    const validation = bookDomain.validatePageProgress(currentPage, existingBook.page_count);
 
     if (!validation.valid) {
       throw new ValidationError(validation.error);
     }
 
     // ステータスを自動計算
-    const newStatus = bookDomain.calculateStatus(
-      currentPage,
-      existingBook.page_count
-    );
+    const newStatus = bookDomain.calculateStatus(currentPage, existingBook.page_count);
 
     // 読了日の設定
-    const finishedAt = bookDomain.shouldSetFinishedAt(
-      newStatus,
-      existingBook.status
-    )
+    const finishedAt = bookDomain.shouldSetFinishedAt(newStatus, existingBook.status)
       ? new Date().toISOString()
       : existingBook.finished_at;
 
@@ -164,7 +149,7 @@ app.patch(
     });
 
     return successResponse(c, toBookResponse(book));
-  }
+  },
 );
 
 /**

--- a/app/server/api/index.ts
+++ b/app/server/api/index.ts
@@ -27,5 +27,3 @@ app.get("/health", (c) => {
 // RPC型エクスポート
 export type AppType = typeof app;
 export default app;
-
-

--- a/app/server/api/schemas/book.ts
+++ b/app/server/api/schemas/book.ts
@@ -68,8 +68,7 @@ export const bookIdSchema = type({
  * 書籍IDパラメータ検証スキーマ
  */
 export const bookIdParamSchema = type({
-  bookId:
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+  bookId: /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
 });
 
 // 型エクスポート

--- a/app/server/api/schemas/index.ts
+++ b/app/server/api/schemas/index.ts
@@ -9,12 +9,7 @@ export {
 } from "./book";
 
 // タグ関連
-export {
-  createTagSchema,
-  updateTagSchema,
-  tagIdSchema,
-  addTagToBookSchema,
-} from "./tag";
+export { createTagSchema, updateTagSchema, tagIdSchema, addTagToBookSchema } from "./tag";
 
 // ユーザー関連
 export { updateUserSchema, usernameSchema } from "./user";
@@ -27,4 +22,3 @@ export {
   rakutenSearchSchema,
   isbnSearchSchema,
 } from "./auth";
-

--- a/app/server/api/schemas/tag.ts
+++ b/app/server/api/schemas/tag.ts
@@ -10,7 +10,7 @@ const tagNamePattern = regex("^[a-zA-Z0-9ぁ-んァ-ヶー一-龠々\\-_]{1,50}$
  */
 const uuidPattern = regex(
   "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
-  "i"
+  "i",
 );
 
 /**

--- a/app/server/api/schemas/user.ts
+++ b/app/server/api/schemas/user.ts
@@ -33,7 +33,7 @@ export const RESERVED_USERNAMES = [
  * ユーザー名が予約語かどうかチェック
  */
 export function isReservedUsername(username: string): boolean {
-  return RESERVED_USERNAMES.includes(username.toLowerCase() as typeof RESERVED_USERNAMES[number]);
+  return RESERVED_USERNAMES.includes(username.toLowerCase() as (typeof RESERVED_USERNAMES)[number]);
 }
 
 /**

--- a/app/server/api/search.test.ts
+++ b/app/server/api/search.test.ts
@@ -1,124 +1,152 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { env } from 'cloudflare:test'
-import api from './index'
-import { createTestSession, createTestUser, cleanupDatabase } from '../../test/helpers'
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { env } from "cloudflare:test";
+import api from "./index";
+import { createTestSession, createTestUser, cleanupDatabase } from "../../test/helpers";
 
-describe('Search API Integration', () => {
+describe("Search API Integration", () => {
   beforeEach(async () => {
-    await cleanupDatabase(env.DB)
-  })
+    await cleanupDatabase(env.DB);
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('should return 401 without session', async () => {
-    const res = await api.request('/search/books?query=react', {}, env)
-    expect(res.status).toBe(401)
-  })
+  it("should return 401 without session", async () => {
+    const res = await api.request("/search/books?query=react", {}, env);
+    expect(res.status).toBe(401);
+  });
 
-  it('should return 400 for invalid query', async () => {
-    const user = await createTestUser(env.DB)
-    const sessionId = await createTestSession(env.KV, user.id)
+  it("should return 400 for invalid query", async () => {
+    const user = await createTestUser(env.DB);
+    const sessionId = await createTestSession(env.KV, user.id);
 
-    const res = await api.request('/search/books?query=', {
-      headers: { Cookie: `session_id=${sessionId}` },
-    }, env)
+    const res = await api.request(
+      "/search/books?query=",
+      {
+        headers: { Cookie: `session_id=${sessionId}` },
+      },
+      env,
+    );
 
-    expect(res.status).toBe(400)
-  })
+    expect(res.status).toBe(400);
+  });
 
-  it('should return search results sorted by published date', async () => {
-    const user = await createTestUser(env.DB)
-    const sessionId = await createTestSession(env.KV, user.id)
+  it("should return search results sorted by published date", async () => {
+    const user = await createTestUser(env.DB);
+    const sessionId = await createTestSession(env.KV, user.id);
 
     const mockResponse = {
       Items: [
         {
           Item: {
-            isbn: '9780000000001',
-            title: 'Older Book',
-            author: 'Author A',
-            publisherName: 'Publisher A',
-            salesDate: '2023年12月1日',
-            size: '200p',
-            itemCaption: 'Older book description',
-            largeImageUrl: 'https://example.com/older.png',
-            affiliateUrl: 'https://example.com/older',
+            isbn: "9780000000001",
+            title: "Older Book",
+            author: "Author A",
+            publisherName: "Publisher A",
+            salesDate: "2023年12月1日",
+            size: "200p",
+            itemCaption: "Older book description",
+            largeImageUrl: "https://example.com/older.png",
+            affiliateUrl: "https://example.com/older",
           },
         },
         {
           Item: {
-            isbn: '9780000000002',
-            title: 'Newer Book',
-            author: 'Author B',
-            publisherName: 'Publisher B',
-            salesDate: '2024年1月2日',
-            size: '320p',
-            itemCaption: 'Newer book description',
-            largeImageUrl: 'https://example.com/newer.png',
-            affiliateUrl: 'https://example.com/newer',
+            isbn: "9780000000002",
+            title: "Newer Book",
+            author: "Author B",
+            publisherName: "Publisher B",
+            salesDate: "2024年1月2日",
+            size: "320p",
+            itemCaption: "Newer book description",
+            largeImageUrl: "https://example.com/newer.png",
+            affiliateUrl: "https://example.com/newer",
           },
         },
       ],
       pageCount: 1,
       hits: 2,
-    }
+    };
 
-    vi.stubGlobal('fetch', vi.fn(async () =>
-      new Response(JSON.stringify(mockResponse), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    ))
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(mockResponse), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
 
-    const res = await api.request('/search/books?query=react&limit=5&page=1', {
-      headers: { Cookie: `session_id=${sessionId}` },
-    }, env)
+    const res = await api.request(
+      "/search/books?query=react&limit=5&page=1",
+      {
+        headers: { Cookie: `session_id=${sessionId}` },
+      },
+      env,
+    );
 
-    expect(res.status).toBe(200)
-    const body = await res.json() as {
-      success: boolean
-      data: { results: Array<{ title: string; publishedDate: string }>; hits: number; pageCount: number }
-    }
-    expect(body.success).toBe(true)
-    expect(body.data.results).toHaveLength(2)
-    expect(body.data.results[0].title).toBe('Newer Book')
-    expect(body.data.results[0].publishedDate).toBe('2024年1月2日')
-    expect(body.data.hits).toBe(2)
-    expect(body.data.pageCount).toBe(1)
-  })
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: {
+        results: Array<{ title: string; publishedDate: string }>;
+        hits: number;
+        pageCount: number;
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.results).toHaveLength(2);
+    expect(body.data.results[0].title).toBe("Newer Book");
+    expect(body.data.results[0].publishedDate).toBe("2024年1月2日");
+    expect(body.data.hits).toBe(2);
+    expect(body.data.pageCount).toBe(1);
+  });
 
-  it('should return 400 for invalid isbn', async () => {
-    const user = await createTestUser(env.DB)
-    const sessionId = await createTestSession(env.KV, user.id)
+  it("should return 400 for invalid isbn", async () => {
+    const user = await createTestUser(env.DB);
+    const sessionId = await createTestSession(env.KV, user.id);
 
-    const res = await api.request('/search/isbn/123', {
-      headers: { Cookie: `session_id=${sessionId}` },
-    }, env)
+    const res = await api.request(
+      "/search/isbn/123",
+      {
+        headers: { Cookie: `session_id=${sessionId}` },
+      },
+      env,
+    );
 
-    expect(res.status).toBe(400)
-  })
+    expect(res.status).toBe(400);
+  });
 
-  it('should return null when ISBN search has no results', async () => {
-    const user = await createTestUser(env.DB)
-    const sessionId = await createTestSession(env.KV, user.id)
+  it("should return null when ISBN search has no results", async () => {
+    const user = await createTestUser(env.DB);
+    const sessionId = await createTestSession(env.KV, user.id);
 
-    const mockResponse = { Items: [], pageCount: 0, hits: 0 }
-    vi.stubGlobal('fetch', vi.fn(async () =>
-      new Response(JSON.stringify(mockResponse), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    ))
+    const mockResponse = { Items: [], pageCount: 0, hits: 0 };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(mockResponse), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
 
-    const res = await api.request('/search/isbn/9784873119038', {
-      headers: { Cookie: `session_id=${sessionId}` },
-    }, env)
+    const res = await api.request(
+      "/search/isbn/9784873119038",
+      {
+        headers: { Cookie: `session_id=${sessionId}` },
+      },
+      env,
+    );
 
-    expect(res.status).toBe(200)
-    const body = await res.json() as { success: boolean; data: null }
-    expect(body.success).toBe(true)
-    expect(body.data).toBeNull()
-  })
-})
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; data: null };
+    expect(body.success).toBe(true);
+    expect(body.data).toBeNull();
+  });
+});

--- a/app/server/api/search.ts
+++ b/app/server/api/search.ts
@@ -22,7 +22,6 @@ app.use("*", searchRateLimiter);
  * GET /api/search/books
  */
 app.get("/books", validator("query", rakutenSearchSchema), async (c) => {
-
   // バリデーション済みのデータを取得
   const { query, limit, page } = getValidated<RakutenSearchInput>(c, "query");
 
@@ -35,7 +34,7 @@ app.get("/books", validator("query", rakutenSearchSchema), async (c) => {
     query,
     c.env.RAKUTEN_APP_ID,
     limit ?? 20,
-    page ?? 1
+    page ?? 1,
   );
 
   const sortedResults = rakutenService.sortByPublishedDateDesc(results);
@@ -64,7 +63,7 @@ app.get("/isbn/:isbn", validator("param", isbnSearchSchema), async (c) => {
           details: "Invalid ISBN",
         },
       },
-      400
+      400,
     );
   }
 

--- a/app/server/api/tags.test.ts
+++ b/app/server/api/tags.test.ts
@@ -1,149 +1,190 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { env } from 'cloudflare:test'
-import api from './index'
-import { createTestUser, createTestSession, createTestBook, createTestTag } from '../../test/helpers'
-import type { SuccessResponse } from '../lib/response'
-import type { TagResponse } from '../../types/database'
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import api from "./index";
+import {
+  createTestUser,
+  createTestSession,
+  createTestBook,
+  createTestTag,
+} from "../../test/helpers";
+import type { SuccessResponse } from "../lib/response";
+import type { TagResponse } from "../../types/database";
 
-describe('Tags API Integration', () => {
-  let userId: string
-  let sessionId: string
+describe("Tags API Integration", () => {
+  let userId: string;
+  let sessionId: string;
 
   beforeEach(async () => {
-    await env.DB.prepare('DELETE FROM book_tags').run()
-    await env.DB.prepare('DELETE FROM tags').run()
-    await env.DB.prepare('DELETE FROM books').run()
-    await env.DB.prepare('DELETE FROM users').run()
+    await env.DB.prepare("DELETE FROM book_tags").run();
+    await env.DB.prepare("DELETE FROM tags").run();
+    await env.DB.prepare("DELETE FROM books").run();
+    await env.DB.prepare("DELETE FROM users").run();
 
-    const user = await createTestUser(env.DB)
-    userId = user.id
-    sessionId = await createTestSession(env.KV, userId)
-  })
+    const user = await createTestUser(env.DB);
+    userId = user.id;
+    sessionId = await createTestSession(env.KV, userId);
+  });
 
-  describe('GET /tags', () => {
-    it('should return empty list when no tags', async () => {
-      const res = await api.request('/tags', {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
-
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<TagResponse[]>
-      expect(body.success).toBe(true)
-      expect(body.data).toEqual([])
-    })
-
-    it('should return tags for authenticated user', async () => {
-      await createTestTag(env.DB, userId, 'JavaScript')
-      await createTestTag(env.DB, userId, 'TypeScript')
-
-      const res = await api.request('/tags', {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
-
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<TagResponse[]>
-      expect(body.data).toHaveLength(2)
-    })
-  })
-
-  describe('POST /tags', () => {
-    it('should create a new tag', async () => {
-      const res = await api.request('/tags', {
-        method: 'POST',
-        headers: {
-          Cookie: `session_id=${sessionId}`,
-          'Content-Type': 'application/json',
+  describe("GET /tags", () => {
+    it("should return empty list when no tags", async () => {
+      const res = await api.request(
+        "/tags",
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
         },
-        body: JSON.stringify({ name: 'React' }),
-      }, env)
+        env,
+      );
 
-      expect(res.status).toBe(201)
-      const body = await res.json() as SuccessResponse<TagResponse>
-      expect(body.success).toBe(true)
-      expect(body.data.name).toBe('React')
-    })
-  })
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<TagResponse[]>;
+      expect(body.success).toBe(true);
+      expect(body.data).toEqual([]);
+    });
 
-  describe('PUT /tags/:id', () => {
-    it('should update a tag', async () => {
-      const tag = await createTestTag(env.DB, userId, 'OldName')
+    it("should return tags for authenticated user", async () => {
+      await createTestTag(env.DB, userId, "JavaScript");
+      await createTestTag(env.DB, userId, "TypeScript");
 
-      const res = await api.request(`/tags/${tag.id}`, {
-        method: 'PUT',
-        headers: {
-          Cookie: `session_id=${sessionId}`,
-          'Content-Type': 'application/json',
+      const res = await api.request(
+        "/tags",
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
         },
-        body: JSON.stringify({ name: 'NewName' }),
-      }, env)
+        env,
+      );
 
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<TagResponse>
-      expect(body.data.name).toBe('NewName')
-    })
-  })
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<TagResponse[]>;
+      expect(body.data).toHaveLength(2);
+    });
+  });
 
-  describe('DELETE /tags/:id', () => {
-    it('should delete a tag', async () => {
-      const tag = await createTestTag(env.DB, userId, 'ToDelete')
-
-      const res = await api.request(`/tags/${tag.id}`, {
-        method: 'DELETE',
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
-
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<{ deleted: boolean }>
-      expect(body.data.deleted).toBe(true)
-    })
-  })
-
-  describe('Book-Tag Association', () => {
-    it('should get tags for a book', async () => {
-      const book = await createTestBook(env.DB, userId)
-      const tag = await createTestTag(env.DB, userId, 'BookTag')
-      await env.DB.prepare('INSERT INTO book_tags (book_id, tag_id) VALUES (?, ?)').bind(book.id, tag.id).run()
-
-      const res = await api.request(`/tags/books/${book.id}`, {
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
-
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<TagResponse[]>
-      expect(body.data).toHaveLength(1)
-    })
-
-    it('should add a tag to a book', async () => {
-      const book = await createTestBook(env.DB, userId)
-      const tag = await createTestTag(env.DB, userId, 'NewTag')
-
-      const res = await api.request(`/tags/books/${book.id}`, {
-        method: 'POST',
-        headers: {
-          Cookie: `session_id=${sessionId}`,
-          'Content-Type': 'application/json',
+  describe("POST /tags", () => {
+    it("should create a new tag", async () => {
+      const res = await api.request(
+        "/tags",
+        {
+          method: "POST",
+          headers: {
+            Cookie: `session_id=${sessionId}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ name: "React" }),
         },
-        body: JSON.stringify({ tagId: tag.id }),
-      }, env)
+        env,
+      );
 
-      expect(res.status).toBe(201)
-      const body = await res.json() as SuccessResponse<{ added: boolean }>
-      expect(body.data.added).toBe(true)
-    })
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as SuccessResponse<TagResponse>;
+      expect(body.success).toBe(true);
+      expect(body.data.name).toBe("React");
+    });
+  });
 
-    it('should remove tag from book', async () => {
-      const book = await createTestBook(env.DB, userId)
-      const tag = await createTestTag(env.DB, userId, 'ToRemove')
-      await env.DB.prepare('INSERT INTO book_tags (book_id, tag_id) VALUES (?, ?)').bind(book.id, tag.id).run()
+  describe("PUT /tags/:id", () => {
+    it("should update a tag", async () => {
+      const tag = await createTestTag(env.DB, userId, "OldName");
 
-      const res = await api.request(`/tags/books/${book.id}/${tag.id}`, {
-        method: 'DELETE',
-        headers: { Cookie: `session_id=${sessionId}` },
-      }, env)
+      const res = await api.request(
+        `/tags/${tag.id}`,
+        {
+          method: "PUT",
+          headers: {
+            Cookie: `session_id=${sessionId}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ name: "NewName" }),
+        },
+        env,
+      );
 
-      expect(res.status).toBe(200)
-      const body = await res.json() as SuccessResponse<{ removed: boolean }>
-      expect(body.data.removed).toBe(true)
-    })
-  })
-})
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<TagResponse>;
+      expect(body.data.name).toBe("NewName");
+    });
+  });
+
+  describe("DELETE /tags/:id", () => {
+    it("should delete a tag", async () => {
+      const tag = await createTestTag(env.DB, userId, "ToDelete");
+
+      const res = await api.request(
+        `/tags/${tag.id}`,
+        {
+          method: "DELETE",
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<{ deleted: boolean }>;
+      expect(body.data.deleted).toBe(true);
+    });
+  });
+
+  describe("Book-Tag Association", () => {
+    it("should get tags for a book", async () => {
+      const book = await createTestBook(env.DB, userId);
+      const tag = await createTestTag(env.DB, userId, "BookTag");
+      await env.DB.prepare("INSERT INTO book_tags (book_id, tag_id) VALUES (?, ?)")
+        .bind(book.id, tag.id)
+        .run();
+
+      const res = await api.request(
+        `/tags/books/${book.id}`,
+        {
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<TagResponse[]>;
+      expect(body.data).toHaveLength(1);
+    });
+
+    it("should add a tag to a book", async () => {
+      const book = await createTestBook(env.DB, userId);
+      const tag = await createTestTag(env.DB, userId, "NewTag");
+
+      const res = await api.request(
+        `/tags/books/${book.id}`,
+        {
+          method: "POST",
+          headers: {
+            Cookie: `session_id=${sessionId}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ tagId: tag.id }),
+        },
+        env,
+      );
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as SuccessResponse<{ added: boolean }>;
+      expect(body.data.added).toBe(true);
+    });
+
+    it("should remove tag from book", async () => {
+      const book = await createTestBook(env.DB, userId);
+      const tag = await createTestTag(env.DB, userId, "ToRemove");
+      await env.DB.prepare("INSERT INTO book_tags (book_id, tag_id) VALUES (?, ?)")
+        .bind(book.id, tag.id)
+        .run();
+
+      const res = await api.request(
+        `/tags/books/${book.id}/${tag.id}`,
+        {
+          method: "DELETE",
+          headers: { Cookie: `session_id=${sessionId}` },
+        },
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as SuccessResponse<{ removed: boolean }>;
+      expect(body.data.removed).toBe(true);
+    });
+  });
+});

--- a/app/server/api/tags.ts
+++ b/app/server/api/tags.ts
@@ -48,20 +48,15 @@ app.post("/", validator("json", createTagSchema), async (c) => {
  * タグ更新
  * PUT /api/tags/:id
  */
-app.put(
-  "/:id",
-  validator("param", tagIdSchema),
-  validator("json", updateTagSchema),
-  async (c) => {
-    const userId = c.get("userId");
-    const { id } = getValidated<{ id: string }>(c, "param");
-    const data = getValidated<UpdateTagInput>(c, "json");
+app.put("/:id", validator("param", tagIdSchema), validator("json", updateTagSchema), async (c) => {
+  const userId = c.get("userId");
+  const { id } = getValidated<{ id: string }>(c, "param");
+  const data = getValidated<UpdateTagInput>(c, "json");
 
-    const tag = await tagRepo.update(c.env.DB, id, userId, data.name);
+  const tag = await tagRepo.update(c.env.DB, id, userId, data.name);
 
-    return successResponse(c, toTagResponse(tag));
-  }
-);
+  return successResponse(c, toTagResponse(tag));
+});
 
 /**
  * タグ削除
@@ -92,7 +87,7 @@ app.post(
     await bookTagRepo.addTagToBook(c.env.DB, bookId, tagId, userId);
 
     return successResponse(c, { added: true }, 201);
-  }
+  },
 );
 
 /**
@@ -114,7 +109,6 @@ app.delete("/books/:bookId/:tagId", async (c) => {
  * GET /api/tags/books/:bookId
  */
 app.get("/books/:bookId", async (c) => {
-  const userId = c.get("userId");
   const bookId = c.req.param("bookId");
 
   const tags = await bookTagRepo.findTagsByBookId(c.env.DB, bookId);
@@ -123,4 +117,3 @@ app.get("/books/:bookId", async (c) => {
 });
 
 export default app;
-

--- a/app/server/api/users.test.ts
+++ b/app/server/api/users.test.ts
@@ -1,129 +1,157 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { env } from 'cloudflare:test'
-import api from './index'
-import { createTestBook, createTestSession, createTestUser, cleanupDatabase } from '../../test/helpers'
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import api from "./index";
+import {
+  createTestBook,
+  createTestSession,
+  createTestUser,
+  cleanupDatabase,
+} from "../../test/helpers";
 
-describe('Users API Integration', () => {
+describe("Users API Integration", () => {
   beforeEach(async () => {
-    await cleanupDatabase(env.DB)
-  })
+    await cleanupDatabase(env.DB);
+  });
 
-  it('should return 401 for /users/me without session', async () => {
-    const res = await api.request('/users/me', {}, env)
-    expect(res.status).toBe(401)
-  })
+  it("should return 401 for /users/me without session", async () => {
+    const res = await api.request("/users/me", {}, env);
+    expect(res.status).toBe(401);
+  });
 
-  it('should return current user info', async () => {
-    const user = await createTestUser(env.DB)
-    const sessionId = await createTestSession(env.KV, user.id)
+  it("should return current user info", async () => {
+    const user = await createTestUser(env.DB);
+    const sessionId = await createTestSession(env.KV, user.id);
 
-    const res = await api.request('/users/me', {
-      headers: { Cookie: `session_id=${sessionId}` },
-    }, env)
-
-    expect(res.status).toBe(200)
-    const body = await res.json() as { success: boolean; data: { id: string; username: string } }
-    expect(body.success).toBe(true)
-    expect(body.data.id).toBe(user.id)
-    expect(body.data.username).toBe(user.username)
-  })
-
-  it('should reject reserved username update', async () => {
-    const user = await createTestUser(env.DB)
-    const sessionId = await createTestSession(env.KV, user.id)
-
-    const res = await api.request('/users/me', {
-      method: 'PUT',
-      headers: {
-        Cookie: `session_id=${sessionId}`,
-        'Content-Type': 'application/json',
+    const res = await api.request(
+      "/users/me",
+      {
+        headers: { Cookie: `session_id=${sessionId}` },
       },
-      body: JSON.stringify({ username: 'admin' }),
-    }, env)
+      env,
+    );
 
-    expect(res.status).toBe(400)
-    const body = await res.json() as { error?: string }
-    expect(body.error).toBe('このユーザー名は使用できません')
-  })
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; data: { id: string; username: string } };
+    expect(body.success).toBe(true);
+    expect(body.data.id).toBe(user.id);
+    expect(body.data.username).toBe(user.username);
+  });
 
-  it('should update user profile fields', async () => {
-    const user = await createTestUser(env.DB)
-    const sessionId = await createTestSession(env.KV, user.id)
+  it("should reject reserved username update", async () => {
+    const user = await createTestUser(env.DB);
+    const sessionId = await createTestSession(env.KV, user.id);
 
-    const res = await api.request('/users/me', {
-      method: 'PUT',
-      headers: {
-        Cookie: `session_id=${sessionId}`,
-        'Content-Type': 'application/json',
+    const res = await api.request(
+      "/users/me",
+      {
+        method: "PUT",
+        headers: {
+          Cookie: `session_id=${sessionId}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username: "admin" }),
       },
-      body: JSON.stringify({
-        name: 'Updated Name',
-        bio: 'Updated bio',
-        avatarUrl: 'https://example.com/avatar.png',
-      }),
-    }, env)
+      env,
+    );
 
-    expect(res.status).toBe(200)
-    const body = await res.json() as { success: boolean; data: { name: string; bio: string; avatarUrl: string } }
-    expect(body.data.name).toBe('Updated Name')
-    expect(body.data.bio).toBe('Updated bio')
-    expect(body.data.avatarUrl).toBe('https://example.com/avatar.png')
-  })
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe("このユーザー名は使用できません");
+  });
 
-  it('should return unavailable for reserved username check', async () => {
-    const res = await api.request('/users/check/admin', {}, env)
-    expect(res.status).toBe(200)
-    const body = await res.json() as { success: boolean; data: { available: boolean; reason?: string } }
-    expect(body.data.available).toBe(false)
-    expect(body.data.reason).toBe('reserved')
-  })
+  it("should update user profile fields", async () => {
+    const user = await createTestUser(env.DB);
+    const sessionId = await createTestSession(env.KV, user.id);
 
-  it('should return unavailable for taken username', async () => {
-    const user = await createTestUser(env.DB)
+    const res = await api.request(
+      "/users/me",
+      {
+        method: "PUT",
+        headers: {
+          Cookie: `session_id=${sessionId}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "Updated Name",
+          bio: "Updated bio",
+          avatarUrl: "https://example.com/avatar.png",
+        }),
+      },
+      env,
+    );
 
-    const res = await api.request(`/users/check/${user.username}`, {}, env)
-    expect(res.status).toBe(200)
-    const body = await res.json() as { success: boolean; data: { available: boolean } }
-    expect(body.data.available).toBe(false)
-  })
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { name: string; bio: string; avatarUrl: string };
+    };
+    expect(body.data.name).toBe("Updated Name");
+    expect(body.data.bio).toBe("Updated bio");
+    expect(body.data.avatarUrl).toBe("https://example.com/avatar.png");
+  });
 
-  it('should return public profile without private fields', async () => {
-    const user = await createTestUser(env.DB)
+  it("should return unavailable for reserved username check", async () => {
+    const res = await api.request("/users/check/admin", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { available: boolean; reason?: string };
+    };
+    expect(body.data.available).toBe(false);
+    expect(body.data.reason).toBe("reserved");
+  });
 
-    const res = await api.request(`/users/${user.username}`, {}, env)
-    expect(res.status).toBe(200)
-    const body = await res.json() as { success: boolean; data: Record<string, unknown> }
-    expect(body.data.username).toBe(user.username)
-    expect('email' in body.data).toBe(false)
-    expect('provider' in body.data).toBe(false)
-  })
+  it("should return unavailable for taken username", async () => {
+    const user = await createTestUser(env.DB);
 
-  it('should return only completed books for public profile', async () => {
-    const user = await createTestUser(env.DB)
-    await createTestBook(env.DB, user.id, { status: 'completed' })
-    await createTestBook(env.DB, user.id, { status: 'reading' })
+    const res = await api.request(`/users/check/${user.username}`, {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; data: { available: boolean } };
+    expect(body.data.available).toBe(false);
+  });
 
-    const res = await api.request(`/users/${user.username}/books`, {}, env)
-    expect(res.status).toBe(200)
-    const body = await res.json() as { success: boolean; data: Array<{ status: string; memo: string | null }> }
-    expect(body.data).toHaveLength(1)
-    expect(body.data[0].status).toBe('completed')
-    expect(body.data[0].memo).toBeNull()
-  })
+  it("should return public profile without private fields", async () => {
+    const user = await createTestUser(env.DB);
 
-  it('should delete user account', async () => {
-    const user = await createTestUser(env.DB)
-    const sessionId = await createTestSession(env.KV, user.id)
+    const res = await api.request(`/users/${user.username}`, {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; data: Record<string, unknown> };
+    expect(body.data.username).toBe(user.username);
+    expect("email" in body.data).toBe(false);
+    expect("provider" in body.data).toBe(false);
+  });
 
-    const res = await api.request('/users/me', {
-      method: 'DELETE',
-      headers: { Cookie: `session_id=${sessionId}` },
-    }, env)
+  it("should return only completed books for public profile", async () => {
+    const user = await createTestUser(env.DB);
+    await createTestBook(env.DB, user.id, { status: "completed" });
+    await createTestBook(env.DB, user.id, { status: "reading" });
 
-    expect(res.status).toBe(200)
-    const result = await env.DB.prepare('SELECT id FROM users WHERE id = ?')
-      .bind(user.id)
-      .first()
-    expect(result).toBeNull()
-  })
-})
+    const res = await api.request(`/users/${user.username}/books`, {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: Array<{ status: string; memo: string | null }>;
+    };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].status).toBe("completed");
+    expect(body.data[0].memo).toBeNull();
+  });
+
+  it("should delete user account", async () => {
+    const user = await createTestUser(env.DB);
+    const sessionId = await createTestSession(env.KV, user.id);
+
+    const res = await api.request(
+      "/users/me",
+      {
+        method: "DELETE",
+        headers: { Cookie: `session_id=${sessionId}` },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    const result = await env.DB.prepare("SELECT id FROM users WHERE id = ?").bind(user.id).first();
+    expect(result).toBeNull();
+  });
+});

--- a/app/server/api/users.ts
+++ b/app/server/api/users.ts
@@ -25,73 +25,59 @@ app.get("/me", authMiddleware, async (c) => {
  * プロフィール更新
  * PUT /api/users/me
  */
-app.put(
-  "/me",
-  authMiddleware,
-  validator("json", updateUserSchema),
-  async (c) => {
-    const userId = c.get("userId");
-    const data = getValidated<UpdateUserInput>(c, "json");
+app.put("/me", authMiddleware, validator("json", updateUserSchema), async (c) => {
+  const userId = c.get("userId");
+  const data = getValidated<UpdateUserInput>(c, "json");
 
-    if (data.username && isReservedUsername(data.username)) {
-      return c.json({ error: "このユーザー名は使用できません" }, 400);
-    }
-
-    const updatedUser = await userRepo.update(c.env.DB, userId, {
-      username: data.username,
-      name: data.name,
-      bio: data.bio,
-      avatar_url: data.avatarUrl,
-    });
-
-    await invalidateUserCache(c.env.KV, userId);
-
-    return successResponse(c, toUserResponse(updatedUser));
+  if (data.username && isReservedUsername(data.username)) {
+    return c.json({ error: "このユーザー名は使用できません" }, 400);
   }
-);
+
+  const updatedUser = await userRepo.update(c.env.DB, userId, {
+    username: data.username,
+    name: data.name,
+    bio: data.bio,
+    avatar_url: data.avatarUrl,
+  });
+
+  await invalidateUserCache(c.env.KV, userId);
+
+  return successResponse(c, toUserResponse(updatedUser));
+});
 
 /**
  * ユーザー名の重複チェック
  * GET /api/users/check/:username
  */
-app.get(
-  "/check/:username",
-  validator("param", usernameSchema),
-  async (c) => {
-    const { username } = getValidated<{ username: string }>(c, "param");
+app.get("/check/:username", validator("param", usernameSchema), async (c) => {
+  const { username } = getValidated<{ username: string }>(c, "param");
 
-    if (isReservedUsername(username)) {
-      return successResponse(c, { available: false, reason: "reserved" });
-    }
-
-    const isTaken = await userRepo.isUsernameTaken(c.env.DB, username);
-
-    return successResponse(c, { available: !isTaken });
+  if (isReservedUsername(username)) {
+    return successResponse(c, { available: false, reason: "reserved" });
   }
-);
+
+  const isTaken = await userRepo.isUsernameTaken(c.env.DB, username);
+
+  return successResponse(c, { available: !isTaken });
+});
 
 /**
  * 公開プロフィール取得
  * GET /api/users/:username
  */
-app.get(
-  "/:username",
-  optionalAuthMiddleware,
-  validator("param", usernameSchema),
-  async (c) => {
-    const { username } = getValidated<{ username: string }>(c, "param");
-    const user = await userRepo.findByUsername(c.env.DB, username);
+app.get("/:username", optionalAuthMiddleware, validator("param", usernameSchema), async (c) => {
+  const { username } = getValidated<{ username: string }>(c, "param");
+  const user = await userRepo.findByUsername(c.env.DB, username);
 
-    // 公開情報のみ返す
-    return successResponse(c, {
-      id: user.id,
-      username: user.username,
-      name: user.name,
-      bio: user.bio,
-      avatarUrl: user.avatar_url,
-    });
-  }
-);
+  // 公開情報のみ返す
+  return successResponse(c, {
+    id: user.id,
+    username: user.username,
+    name: user.name,
+    bio: user.bio,
+    avatarUrl: user.avatar_url,
+  });
+});
 
 /**
  * ユーザーの公開書籍一覧
@@ -114,7 +100,7 @@ app.get("/:username/books", optionalAuthMiddleware, async (c) => {
       ...toBookResponse(book),
       // 公開用に一部フィールドを隠す
       memo: null,
-    }))
+    })),
   );
 });
 
@@ -130,4 +116,3 @@ app.delete("/me", authMiddleware, async (c) => {
 });
 
 export default app;
-

--- a/app/server/db/repositories/book.test.ts
+++ b/app/server/db/repositories/book.test.ts
@@ -1,217 +1,209 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { env } from 'cloudflare:test'
-import * as bookRepo from './book'
-import { createTestUser, createTestBook } from '../../../test/helpers'
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import * as bookRepo from "./book";
+import { createTestUser, createTestBook } from "../../../test/helpers";
 
-describe('Book Repository', () => {
-  let userId: string
+describe("Book Repository", () => {
+  let userId: string;
 
   beforeEach(async () => {
     // テストデータをクリーンアップ
-    await env.DB.exec('DELETE FROM book_tags')
-    await env.DB.exec('DELETE FROM tags')
-    await env.DB.exec('DELETE FROM books')
-    await env.DB.exec('DELETE FROM users')
+    await env.DB.exec("DELETE FROM book_tags");
+    await env.DB.exec("DELETE FROM tags");
+    await env.DB.exec("DELETE FROM books");
+    await env.DB.exec("DELETE FROM users");
 
     // テストユーザーを作成
-    const user = await createTestUser(env.DB)
-    userId = user.id
-  })
+    const user = await createTestUser(env.DB);
+    userId = user.id;
+  });
 
-  describe('create', () => {
-    it('should create a book', async () => {
-      const now = new Date().toISOString()
-      const bookId = crypto.randomUUID()
+  describe("create", () => {
+    it("should create a book", async () => {
+      const now = new Date().toISOString();
+      const bookId = crypto.randomUUID();
 
       const book = await bookRepo.create(env.DB, {
         id: bookId,
         userId,
-        title: 'Test Book',
-        authors: ['Author 1'],
-        status: 'unread',
+        title: "Test Book",
+        authors: ["Author 1"],
+        status: "unread",
         currentPage: 0,
         createdAt: now,
         updatedAt: now,
-      })
+      });
 
-      expect(book.id).toBe(bookId)
-      expect(book.title).toBe('Test Book')
-      expect(book.user_id).toBe(userId)
-    })
-  })
+      expect(book.id).toBe(bookId);
+      expect(book.title).toBe("Test Book");
+      expect(book.user_id).toBe(userId);
+    });
+  });
 
-  describe('findById', () => {
-    it('should find a book by id', async () => {
-      const created = await createTestBook(env.DB, userId, { title: 'Find Me' })
+  describe("findById", () => {
+    it("should find a book by id", async () => {
+      const created = await createTestBook(env.DB, userId, { title: "Find Me" });
 
-      const book = await bookRepo.findById(env.DB, created.id, userId)
+      const book = await bookRepo.findById(env.DB, created.id, userId);
 
-      expect(book.id).toBe(created.id)
-      expect(book.title).toBe('Find Me')
-    })
+      expect(book.id).toBe(created.id);
+      expect(book.title).toBe("Find Me");
+    });
 
-    it('should throw NotFoundError for non-existent book', async () => {
-      await expect(
-        bookRepo.findById(env.DB, 'non-existent', userId)
-      ).rejects.toThrow('Book not found')
-    })
+    it("should throw NotFoundError for non-existent book", async () => {
+      await expect(bookRepo.findById(env.DB, "non-existent", userId)).rejects.toThrow(
+        "Book not found",
+      );
+    });
 
-    it('should not return books from other users', async () => {
-      const otherUser = await createTestUser(env.DB)
-      const otherBook = await createTestBook(env.DB, otherUser.id)
+    it("should not return books from other users", async () => {
+      const otherUser = await createTestUser(env.DB);
+      const otherBook = await createTestBook(env.DB, otherUser.id);
 
-      await expect(
-        bookRepo.findById(env.DB, otherBook.id, userId)
-      ).rejects.toThrow('Book not found')
-    })
-  })
+      await expect(bookRepo.findById(env.DB, otherBook.id, userId)).rejects.toThrow(
+        "Book not found",
+      );
+    });
+  });
 
-  describe('findByUserId', () => {
-    it('should return books for a user', async () => {
-      await createTestBook(env.DB, userId, { title: 'Book 1' })
-      await createTestBook(env.DB, userId, { title: 'Book 2' })
+  describe("findByUserId", () => {
+    it("should return books for a user", async () => {
+      await createTestBook(env.DB, userId, { title: "Book 1" });
+      await createTestBook(env.DB, userId, { title: "Book 2" });
 
-      const { books, total } = await bookRepo.findByUserId(env.DB, userId)
+      const { books, total } = await bookRepo.findByUserId(env.DB, userId);
 
-      expect(books).toHaveLength(2)
-      expect(total).toBe(2)
-    })
+      expect(books).toHaveLength(2);
+      expect(total).toBe(2);
+    });
 
-    it('should filter by status', async () => {
-      await createTestBook(env.DB, userId, { status: 'reading' })
-      await createTestBook(env.DB, userId, { status: 'unread' })
-      await createTestBook(env.DB, userId, { status: 'completed' })
+    it("should filter by status", async () => {
+      await createTestBook(env.DB, userId, { status: "reading" });
+      await createTestBook(env.DB, userId, { status: "unread" });
+      await createTestBook(env.DB, userId, { status: "completed" });
 
       const { books, total } = await bookRepo.findByUserId(env.DB, userId, {
-        status: 'reading',
-      })
+        status: "reading",
+      });
 
-      expect(books).toHaveLength(1)
-      expect(total).toBe(1)
-      expect(books[0].status).toBe('reading')
-    })
+      expect(books).toHaveLength(1);
+      expect(total).toBe(1);
+      expect(books[0].status).toBe("reading");
+    });
 
-    it('should support pagination', async () => {
+    it("should support pagination", async () => {
       for (let i = 0; i < 5; i++) {
-        await createTestBook(env.DB, userId, { title: `Book ${i}` })
+        await createTestBook(env.DB, userId, { title: `Book ${i}` });
       }
 
       const { books: page1 } = await bookRepo.findByUserId(env.DB, userId, {
         limit: 2,
         offset: 0,
-      })
+      });
       const { books: page2 } = await bookRepo.findByUserId(env.DB, userId, {
         limit: 2,
         offset: 2,
-      })
+      });
 
-      expect(page1).toHaveLength(2)
-      expect(page2).toHaveLength(2)
-    })
+      expect(page1).toHaveLength(2);
+      expect(page2).toHaveLength(2);
+    });
 
-    it('should search by title', async () => {
-      await createTestBook(env.DB, userId, { title: 'JavaScript Guide' })
-      await createTestBook(env.DB, userId, { title: 'Python Guide' })
+    it("should search by title", async () => {
+      await createTestBook(env.DB, userId, { title: "JavaScript Guide" });
+      await createTestBook(env.DB, userId, { title: "Python Guide" });
 
       const { books, total } = await bookRepo.findByUserId(env.DB, userId, {
-        search: 'JavaScript',
-      })
+        search: "JavaScript",
+      });
 
-      expect(books).toHaveLength(1)
-      expect(total).toBe(1)
-      expect(books[0].title).toBe('JavaScript Guide')
-    })
-  })
+      expect(books).toHaveLength(1);
+      expect(total).toBe(1);
+      expect(books[0].title).toBe("JavaScript Guide");
+    });
+  });
 
-  describe('update', () => {
-    it('should update book fields', async () => {
-      const created = await createTestBook(env.DB, userId, { title: 'Old Title' })
+  describe("update", () => {
+    it("should update book fields", async () => {
+      const created = await createTestBook(env.DB, userId, { title: "Old Title" });
 
       const updated = await bookRepo.update(env.DB, created.id, userId, {
-        title: 'New Title',
-        status: 'reading',
-      })
+        title: "New Title",
+        status: "reading",
+      });
 
-      expect(updated.title).toBe('New Title')
-      expect(updated.status).toBe('reading')
-    })
-  })
+      expect(updated.title).toBe("New Title");
+      expect(updated.status).toBe("reading");
+    });
+  });
 
-  describe('updateProgress', () => {
-    it('should update progress and status', async () => {
+  describe("updateProgress", () => {
+    it("should update progress and status", async () => {
       const created = await createTestBook(env.DB, userId, {
         pageCount: 100,
         currentPage: 0,
-        status: 'unread',
-      })
+        status: "unread",
+      });
 
-      const updated = await bookRepo.updateProgress(
-        env.DB,
-        created.id,
-        userId,
-        50,
-        'reading'
-      )
+      const updated = await bookRepo.updateProgress(env.DB, created.id, userId, 50, "reading");
 
-      expect(updated.current_page).toBe(50)
-      expect(updated.status).toBe('reading')
-    })
-  })
+      expect(updated.current_page).toBe(50);
+      expect(updated.status).toBe("reading");
+    });
+  });
 
-  describe('deleteById', () => {
-    it('should delete a book', async () => {
-      const created = await createTestBook(env.DB, userId)
+  describe("deleteById", () => {
+    it("should delete a book", async () => {
+      const created = await createTestBook(env.DB, userId);
 
-      await bookRepo.deleteById(env.DB, created.id, userId)
+      await bookRepo.deleteById(env.DB, created.id, userId);
 
-      await expect(
-        bookRepo.findById(env.DB, created.id, userId)
-      ).rejects.toThrow('Book not found')
-    })
-  })
+      await expect(bookRepo.findById(env.DB, created.id, userId)).rejects.toThrow("Book not found");
+    });
+  });
 
-  describe('getStats', () => {
-    it('should return correct statistics', async () => {
-      await createTestBook(env.DB, userId, { status: 'reading' })
-      await createTestBook(env.DB, userId, { status: 'reading' })
-      await createTestBook(env.DB, userId, { status: 'completed' })
-      await createTestBook(env.DB, userId, { status: 'unread' })
+  describe("getStats", () => {
+    it("should return correct statistics", async () => {
+      await createTestBook(env.DB, userId, { status: "reading" });
+      await createTestBook(env.DB, userId, { status: "reading" });
+      await createTestBook(env.DB, userId, { status: "completed" });
+      await createTestBook(env.DB, userId, { status: "unread" });
 
-      const stats = await bookRepo.getStats(env.DB, userId)
+      const stats = await bookRepo.getStats(env.DB, userId);
 
-      expect(stats.total).toBe(4)
-      expect(stats.reading).toBe(2)
-      expect(stats.completed).toBe(1)
-      expect(stats.unread).toBe(1)
-    })
+      expect(stats.total).toBe(4);
+      expect(stats.reading).toBe(2);
+      expect(stats.completed).toBe(1);
+      expect(stats.unread).toBe(1);
+    });
 
-    it('should return zeros for user with no books', async () => {
-      const stats = await bookRepo.getStats(env.DB, userId)
+    it("should return zeros for user with no books", async () => {
+      const stats = await bookRepo.getStats(env.DB, userId);
 
       // D1 returns null for SUM of empty result, so we check for 0 or null
-      expect(stats.total).toBe(0)
-      expect(stats.reading ?? 0).toBe(0)
-      expect(stats.completed ?? 0).toBe(0)
-      expect(stats.unread ?? 0).toBe(0)
-    })
-  })
+      expect(stats.total).toBe(0);
+      expect(stats.reading ?? 0).toBe(0);
+      expect(stats.completed ?? 0).toBe(0);
+      expect(stats.unread ?? 0).toBe(0);
+    });
+  });
 
-  describe('belongsToUser', () => {
-    it('should return true for user own book', async () => {
-      const book = await createTestBook(env.DB, userId)
+  describe("belongsToUser", () => {
+    it("should return true for user own book", async () => {
+      const book = await createTestBook(env.DB, userId);
 
-      const result = await bookRepo.belongsToUser(env.DB, book.id, userId)
+      const result = await bookRepo.belongsToUser(env.DB, book.id, userId);
 
-      expect(result).toBe(true)
-    })
+      expect(result).toBe(true);
+    });
 
-    it('should return false for other user book', async () => {
-      const otherUser = await createTestUser(env.DB)
-      const otherBook = await createTestBook(env.DB, otherUser.id)
+    it("should return false for other user book", async () => {
+      const otherUser = await createTestUser(env.DB);
+      const otherBook = await createTestBook(env.DB, otherUser.id);
 
-      const result = await bookRepo.belongsToUser(env.DB, otherBook.id, userId)
+      const result = await bookRepo.belongsToUser(env.DB, otherBook.id, userId);
 
-      expect(result).toBe(false)
-    })
-  })
-})
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/app/server/db/repositories/book.ts
+++ b/app/server/db/repositories/book.ts
@@ -1,10 +1,4 @@
-import type {
-  Book,
-  BookInput,
-  BookFilter,
-  BookStats,
-  BookStatus,
-} from "../../../types/database";
+import type { Book, BookInput, BookFilter, BookStats, BookStatus } from "../../../types/database";
 import { NotFoundError, DatabaseError } from "../../lib/errors";
 
 import type { Env } from "../../../types/env";
@@ -18,7 +12,7 @@ type D1BindValue = string | number | null;
 export async function findByUserId(
   db: D1Database,
   userId: string,
-  filter?: BookFilter & { limit?: number; offset?: number }
+  filter?: BookFilter & { limit?: number; offset?: number },
 ): Promise<{ books: Book[]; total: number }> {
   try {
     let query = "SELECT * FROM books WHERE user_id = ?";
@@ -88,11 +82,7 @@ export async function findByUserId(
 /**
  * IDで書籍を取得
  */
-export async function findById(
-  db: D1Database,
-  bookId: string,
-  userId: string
-): Promise<Book> {
+export async function findById(db: D1Database, bookId: string, userId: string): Promise<Book> {
   try {
     const result = await db
       .prepare("SELECT * FROM books WHERE id = ? AND user_id = ?")
@@ -124,7 +114,7 @@ export async function create(db: D1Database, book: BookInput): Promise<Book> {
           rakuten_affiliate_url, status, current_page, memo, finished_at,
           created_at, updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `
+      `,
       )
       .bind(
         book.id,
@@ -144,7 +134,7 @@ export async function create(db: D1Database, book: BookInput): Promise<Book> {
         book.memo || null,
         book.finishedAt || null,
         book.createdAt,
-        book.updatedAt
+        book.updatedAt,
       )
       .run();
 
@@ -161,7 +151,7 @@ export async function update(
   db: D1Database,
   bookId: string,
   userId: string,
-  data: Partial<BookInput>
+  data: Partial<BookInput>,
 ): Promise<Book> {
   try {
     // 書籍の存在確認
@@ -169,10 +159,7 @@ export async function update(
 
     const updates = [
       ["title", data.title],
-      [
-        "authors",
-        data.authors === undefined ? undefined : JSON.stringify(data.authors),
-      ],
+      ["authors", data.authors === undefined ? undefined : JSON.stringify(data.authors)],
       ["publisher", data.publisher],
       ["published_date", data.publishedDate],
       ["isbn", data.isbn],
@@ -187,14 +174,11 @@ export async function update(
       ["finished_at", data.finishedAt],
     ] satisfies Array<[string, D1BindValue | undefined]>;
 
-    const definedUpdates = updates.filter(
-      ([, value]) => value !== undefined
-    ) as Array<[string, D1BindValue]>;
+    const definedUpdates = updates.filter(([, value]) => value !== undefined) as Array<
+      [string, D1BindValue]
+    >;
 
-    const fields = [
-      ...definedUpdates.map(([field]) => `${field} = ?`),
-      "updated_at = ?",
-    ];
+    const fields = [...definedUpdates.map(([field]) => `${field} = ?`), "updated_at = ?"];
     const params: D1BindValue[] = [
       ...definedUpdates.map(([, value]) => value),
       data.updatedAt || new Date().toISOString(),
@@ -208,7 +192,7 @@ export async function update(
         UPDATE books 
         SET ${fields.join(", ")}
         WHERE id = ? AND user_id = ?
-      `
+      `,
       )
       .bind(...params)
       .run();
@@ -229,7 +213,7 @@ export async function updateProgress(
   bookId: string,
   userId: string,
   currentPage: number,
-  status: BookStatus
+  status: BookStatus,
 ): Promise<Book> {
   try {
     // 書籍の存在確認
@@ -241,7 +225,7 @@ export async function updateProgress(
         UPDATE books 
         SET current_page = ?, status = ?, updated_at = ?
         WHERE id = ? AND user_id = ?
-      `
+      `,
       )
       .bind(currentPage, status, new Date().toISOString(), bookId, userId)
       .run();
@@ -256,11 +240,7 @@ export async function updateProgress(
 /**
  * 書籍を削除（関連するタグも削除）
  */
-export async function deleteById(
-  db: D1Database,
-  bookId: string,
-  userId: string
-): Promise<void> {
+export async function deleteById(db: D1Database, bookId: string, userId: string): Promise<void> {
   try {
     // 書籍の存在確認
     await findById(db, bookId, userId);
@@ -268,9 +248,7 @@ export async function deleteById(
     // トランザクション的に削除（D1のbatch機能を使用）
     await db.batch([
       db.prepare("DELETE FROM book_tags WHERE book_id = ?").bind(bookId),
-      db
-        .prepare("DELETE FROM books WHERE id = ? AND user_id = ?")
-        .bind(bookId, userId),
+      db.prepare("DELETE FROM books WHERE id = ? AND user_id = ?").bind(bookId, userId),
     ]);
   } catch (error) {
     if (error instanceof NotFoundError) throw error;
@@ -281,10 +259,7 @@ export async function deleteById(
 /**
  * ユーザーの統計情報を取得
  */
-export async function getStats(
-  db: D1Database,
-  userId: string
-): Promise<BookStats> {
+export async function getStats(db: D1Database, userId: string): Promise<BookStats> {
   try {
     const result = await db
       .prepare(
@@ -296,7 +271,7 @@ export async function getStats(
           SUM(CASE WHEN status = 'unread' THEN 1 ELSE 0 END) as unread
         FROM books 
         WHERE user_id = ?
-      `
+      `,
       )
       .bind(userId)
       .first<BookStats>();
@@ -320,7 +295,7 @@ export async function getStats(
 export async function belongsToUser(
   db: D1Database,
   bookId: string,
-  userId: string
+  userId: string,
 ): Promise<boolean> {
   try {
     const result = await db

--- a/app/server/db/repositories/bookTag.test.ts
+++ b/app/server/db/repositories/bookTag.test.ts
@@ -1,105 +1,110 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { env } from 'cloudflare:test'
-import * as bookTagRepo from './bookTag'
-import { createTestBook, createTestTag, createTestUser, cleanupDatabase } from '../../../test/helpers'
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import * as bookTagRepo from "./bookTag";
+import {
+  createTestBook,
+  createTestTag,
+  createTestUser,
+  cleanupDatabase,
+} from "../../../test/helpers";
 
-describe('BookTag Repository', () => {
-  let userId: string
-  let bookId: string
-  let tagId: string
+describe("BookTag Repository", () => {
+  let userId: string;
+  let bookId: string;
+  let tagId: string;
 
   beforeEach(async () => {
-    await cleanupDatabase(env.DB)
-    const user = await createTestUser(env.DB)
-    userId = user.id
-    const book = await createTestBook(env.DB, userId)
-    bookId = book.id
-    const tag = await createTestTag(env.DB, userId, 'OwnedTag')
-    tagId = tag.id
-  })
+    await cleanupDatabase(env.DB);
+    const user = await createTestUser(env.DB);
+    userId = user.id;
+    const book = await createTestBook(env.DB, userId);
+    bookId = book.id;
+    const tag = await createTestTag(env.DB, userId, "OwnedTag");
+    tagId = tag.id;
+  });
 
-  it('should add a tag to a book', async () => {
-    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId)
+  it("should add a tag to a book", async () => {
+    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId);
 
-    const attached = await bookTagRepo.isTagAttached(env.DB, bookId, tagId)
-    expect(attached).toBe(true)
-  })
+    const attached = await bookTagRepo.isTagAttached(env.DB, bookId, tagId);
+    expect(attached).toBe(true);
+  });
 
-  it('should ignore duplicate tag attachment', async () => {
-    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId)
-    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId)
+  it("should ignore duplicate tag attachment", async () => {
+    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId);
+    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId);
 
-    const count = await bookTagRepo.countTagsByBook(env.DB, bookId)
-    expect(count).toBe(1)
-  })
+    const count = await bookTagRepo.countTagsByBook(env.DB, bookId);
+    expect(count).toBe(1);
+  });
 
-  it('should remove tag from book', async () => {
-    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId)
-    await bookTagRepo.removeTagFromBook(env.DB, bookId, tagId, userId)
+  it("should remove tag from book", async () => {
+    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId);
+    await bookTagRepo.removeTagFromBook(env.DB, bookId, tagId, userId);
 
-    const attached = await bookTagRepo.isTagAttached(env.DB, bookId, tagId)
-    expect(attached).toBe(false)
-  })
+    const attached = await bookTagRepo.isTagAttached(env.DB, bookId, tagId);
+    expect(attached).toBe(false);
+  });
 
-  it('should reject adding tag for missing book', async () => {
-    await expect(
-      bookTagRepo.addTagToBook(env.DB, 'missing-book', tagId, userId)
-    ).rejects.toThrow('Book not found')
-  })
+  it("should reject adding tag for missing book", async () => {
+    await expect(bookTagRepo.addTagToBook(env.DB, "missing-book", tagId, userId)).rejects.toThrow(
+      "Book not found",
+    );
+  });
 
-  it('should reject adding tag for missing tag', async () => {
-    await expect(
-      bookTagRepo.addTagToBook(env.DB, bookId, 'missing-tag', userId)
-    ).rejects.toThrow('Tag not found')
-  })
+  it("should reject adding tag for missing tag", async () => {
+    await expect(bookTagRepo.addTagToBook(env.DB, bookId, "missing-tag", userId)).rejects.toThrow(
+      "Tag not found",
+    );
+  });
 
-  it('should reject adding tag for other user book', async () => {
-    const otherUser = await createTestUser(env.DB)
-    const otherBook = await createTestBook(env.DB, otherUser.id)
+  it("should reject adding tag for other user book", async () => {
+    const otherUser = await createTestUser(env.DB);
+    const otherBook = await createTestBook(env.DB, otherUser.id);
 
-    await expect(
-      bookTagRepo.addTagToBook(env.DB, otherBook.id, tagId, userId)
-    ).rejects.toThrow("You don't own this book")
-  })
+    await expect(bookTagRepo.addTagToBook(env.DB, otherBook.id, tagId, userId)).rejects.toThrow(
+      "You don't own this book",
+    );
+  });
 
-  it('should reject adding tag for other user tag', async () => {
-    const otherUser = await createTestUser(env.DB)
-    const otherTag = await createTestTag(env.DB, otherUser.id, 'OtherTag')
+  it("should reject adding tag for other user tag", async () => {
+    const otherUser = await createTestUser(env.DB);
+    const otherTag = await createTestTag(env.DB, otherUser.id, "OtherTag");
 
-    await expect(
-      bookTagRepo.addTagToBook(env.DB, bookId, otherTag.id, userId)
-    ).rejects.toThrow("You don't own this tag")
-  })
+    await expect(bookTagRepo.addTagToBook(env.DB, bookId, otherTag.id, userId)).rejects.toThrow(
+      "You don't own this tag",
+    );
+  });
 
-  it('should return tags for a book', async () => {
-    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId)
+  it("should return tags for a book", async () => {
+    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId);
 
-    const tags = await bookTagRepo.findTagsByBookId(env.DB, bookId)
-    expect(tags).toHaveLength(1)
-    expect(tags[0].id).toBe(tagId)
-  })
+    const tags = await bookTagRepo.findTagsByBookId(env.DB, bookId);
+    expect(tags).toHaveLength(1);
+    expect(tags[0].id).toBe(tagId);
+  });
 
-  it('should count tags and books', async () => {
-    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId)
+  it("should count tags and books", async () => {
+    await bookTagRepo.addTagToBook(env.DB, bookId, tagId, userId);
 
-    const tagCount = await bookTagRepo.countTagsByBook(env.DB, bookId)
-    const bookCount = await bookTagRepo.countBooksByTag(env.DB, tagId)
+    const tagCount = await bookTagRepo.countTagsByBook(env.DB, bookId);
+    const bookCount = await bookTagRepo.countBooksByTag(env.DB, tagId);
 
-    expect(tagCount).toBe(1)
-    expect(bookCount).toBe(1)
-  })
+    expect(tagCount).toBe(1);
+    expect(bookCount).toBe(1);
+  });
 
-  it('should update book tags in bulk', async () => {
-    const extraTag = await createTestTag(env.DB, userId, 'ExtraTag')
+  it("should update book tags in bulk", async () => {
+    const extraTag = await createTestTag(env.DB, userId, "ExtraTag");
 
-    await bookTagRepo.updateBookTags(env.DB, bookId, [tagId, extraTag.id])
+    await bookTagRepo.updateBookTags(env.DB, bookId, [tagId, extraTag.id]);
 
-    const tagCount = await bookTagRepo.countTagsByBook(env.DB, bookId)
-    expect(tagCount).toBe(2)
+    const tagCount = await bookTagRepo.countTagsByBook(env.DB, bookId);
+    expect(tagCount).toBe(2);
 
-    await bookTagRepo.updateBookTags(env.DB, bookId, [extraTag.id])
-    const tags = await bookTagRepo.findTagsByBookId(env.DB, bookId)
-    expect(tags).toHaveLength(1)
-    expect(tags[0].id).toBe(extraTag.id)
-  })
-})
+    await bookTagRepo.updateBookTags(env.DB, bookId, [extraTag.id]);
+    const tags = await bookTagRepo.findTagsByBookId(env.DB, bookId);
+    expect(tags).toHaveLength(1);
+    expect(tags[0].id).toBe(extraTag.id);
+  });
+});

--- a/app/server/db/repositories/bookTag.ts
+++ b/app/server/db/repositories/bookTag.ts
@@ -11,7 +11,7 @@ export async function addTagToBook(
   db: D1Database,
   bookId: string,
   tagId: string,
-  userId: string
+  userId: string,
 ): Promise<void> {
   try {
     // 書籍の所有権チェック
@@ -51,7 +51,7 @@ export async function addTagToBook(
         `
         INSERT INTO book_tags (book_id, tag_id)
         VALUES (?, ?)
-      `
+      `,
       )
       .bind(bookId, tagId)
       .run();
@@ -70,7 +70,7 @@ export async function removeTagFromBook(
   db: D1Database,
   bookId: string,
   tagId: string,
-  userId: string
+  userId: string,
 ): Promise<void> {
   try {
     // 書籍の所有権チェック
@@ -101,10 +101,7 @@ export async function removeTagFromBook(
 /**
  * 書籍に紐づくタグ一覧を取得
  */
-export async function findTagsByBookId(
-  db: D1Database,
-  bookId: string
-): Promise<Tag[]> {
+export async function findTagsByBookId(db: D1Database, bookId: string): Promise<Tag[]> {
   try {
     const result = await db
       .prepare(
@@ -113,7 +110,7 @@ export async function findTagsByBookId(
         INNER JOIN book_tags bt ON t.id = bt.tag_id
         WHERE bt.book_id = ?
         ORDER BY t.name ASC
-      `
+      `,
       )
       .bind(bookId)
       .all<Tag>();
@@ -127,15 +124,9 @@ export async function findTagsByBookId(
 /**
  * 書籍の全タグを削除
  */
-export async function removeAllTagsFromBook(
-  db: D1Database,
-  bookId: string
-): Promise<void> {
+export async function removeAllTagsFromBook(db: D1Database, bookId: string): Promise<void> {
   try {
-    await db
-      .prepare("DELETE FROM book_tags WHERE book_id = ?")
-      .bind(bookId)
-      .run();
+    await db.prepare("DELETE FROM book_tags WHERE book_id = ?").bind(bookId).run();
   } catch (error) {
     throw new DatabaseError("Failed to remove all tags from book", error);
   }
@@ -147,7 +138,7 @@ export async function removeAllTagsFromBook(
 export async function isTagAttached(
   db: D1Database,
   bookId: string,
-  tagId: string
+  tagId: string,
 ): Promise<boolean> {
   try {
     const result = await db
@@ -164,10 +155,7 @@ export async function isTagAttached(
 /**
  * 書籍に紐づくタグの数を取得
  */
-export async function countTagsByBook(
-  db: D1Database,
-  bookId: string
-): Promise<number> {
+export async function countTagsByBook(db: D1Database, bookId: string): Promise<number> {
   try {
     const result = await db
       .prepare("SELECT COUNT(*) as count FROM book_tags WHERE book_id = ?")
@@ -183,10 +171,7 @@ export async function countTagsByBook(
 /**
  * タグに紐づく書籍の数を取得
  */
-export async function countBooksByTag(
-  db: D1Database,
-  tagId: string
-): Promise<number> {
+export async function countBooksByTag(db: D1Database, tagId: string): Promise<number> {
   try {
     const result = await db
       .prepare("SELECT COUNT(*) as count FROM book_tags WHERE tag_id = ?")
@@ -205,7 +190,7 @@ export async function countBooksByTag(
 export async function updateBookTags(
   db: D1Database,
   bookId: string,
-  tagIds: string[]
+  tagIds: string[],
 ): Promise<void> {
   try {
     // 既存のタグを削除
@@ -214,9 +199,7 @@ export async function updateBookTags(
     // 新しいタグを追加
     if (tagIds.length > 0) {
       const statements = tagIds.map((tagId) =>
-        db
-          .prepare("INSERT INTO book_tags (book_id, tag_id) VALUES (?, ?)")
-          .bind(bookId, tagId)
+        db.prepare("INSERT INTO book_tags (book_id, tag_id) VALUES (?, ?)").bind(bookId, tagId),
       );
 
       await db.batch(statements);

--- a/app/server/db/repositories/index.ts
+++ b/app/server/db/repositories/index.ts
@@ -6,4 +6,3 @@ export * as bookRepo from "./book";
 export * as userRepo from "./user";
 export * as tagRepo from "./tag";
 export * as bookTagRepo from "./bookTag";
-

--- a/app/server/db/repositories/tag.test.ts
+++ b/app/server/db/repositories/tag.test.ts
@@ -1,108 +1,104 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { env } from 'cloudflare:test'
-import * as tagRepo from './tag'
-import { createTestTag, createTestUser, cleanupDatabase } from '../../../test/helpers'
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import * as tagRepo from "./tag";
+import { createTestTag, createTestUser, cleanupDatabase } from "../../../test/helpers";
 
-describe('Tag Repository', () => {
-  let userId: string
+describe("Tag Repository", () => {
+  let userId: string;
 
   beforeEach(async () => {
-    await cleanupDatabase(env.DB)
-    const user = await createTestUser(env.DB)
-    userId = user.id
-  })
+    await cleanupDatabase(env.DB);
+    const user = await createTestUser(env.DB);
+    userId = user.id;
+  });
 
-  it('should return tags for a user', async () => {
-    await createTestTag(env.DB, userId, 'Alpha')
-    await createTestTag(env.DB, userId, 'Beta')
+  it("should return tags for a user", async () => {
+    await createTestTag(env.DB, userId, "Alpha");
+    await createTestTag(env.DB, userId, "Beta");
 
-    const tags = await tagRepo.findByUserId(env.DB, userId)
-    expect(tags).toHaveLength(2)
-  })
+    const tags = await tagRepo.findByUserId(env.DB, userId);
+    expect(tags).toHaveLength(2);
+  });
 
-  it('should find tag by id', async () => {
-    const tag = await createTestTag(env.DB, userId, 'FindMe')
+  it("should find tag by id", async () => {
+    const tag = await createTestTag(env.DB, userId, "FindMe");
 
-    const found = await tagRepo.findById(env.DB, tag.id, userId)
-    expect(found.id).toBe(tag.id)
-  })
+    const found = await tagRepo.findById(env.DB, tag.id, userId);
+    expect(found.id).toBe(tag.id);
+  });
 
-  it('should throw when tag not found', async () => {
-    await expect(
-      tagRepo.findById(env.DB, 'missing-tag', userId)
-    ).rejects.toThrow('Tag not found')
-  })
+  it("should throw when tag not found", async () => {
+    await expect(tagRepo.findById(env.DB, "missing-tag", userId)).rejects.toThrow("Tag not found");
+  });
 
-  it('should find tag by name', async () => {
-    const tag = await createTestTag(env.DB, userId, 'React')
+  it("should find tag by name", async () => {
+    const tag = await createTestTag(env.DB, userId, "React");
 
-    const found = await tagRepo.findByName(env.DB, 'React', userId)
-    expect(found?.id).toBe(tag.id)
-  })
+    const found = await tagRepo.findByName(env.DB, "React", userId);
+    expect(found?.id).toBe(tag.id);
+  });
 
-  it('should return null when name not found', async () => {
-    const found = await tagRepo.findByName(env.DB, 'Missing', userId)
-    expect(found).toBeNull()
-  })
+  it("should return null when name not found", async () => {
+    const found = await tagRepo.findByName(env.DB, "Missing", userId);
+    expect(found).toBeNull();
+  });
 
-  it('should create a tag', async () => {
+  it("should create a tag", async () => {
     const created = await tagRepo.create(env.DB, {
-      id: 'tag-1',
+      id: "tag-1",
       userId,
-      name: 'NewTag',
+      name: "NewTag",
       createdAt: new Date().toISOString(),
-    })
+    });
 
-    expect(created.name).toBe('NewTag')
-  })
+    expect(created.name).toBe("NewTag");
+  });
 
-  it('should reject duplicate tag names', async () => {
-    await createTestTag(env.DB, userId, 'Duplicate')
+  it("should reject duplicate tag names", async () => {
+    await createTestTag(env.DB, userId, "Duplicate");
 
     await expect(
       tagRepo.create(env.DB, {
-        id: 'tag-2',
+        id: "tag-2",
         userId,
-        name: 'Duplicate',
+        name: "Duplicate",
         createdAt: new Date().toISOString(),
-      })
-    ).rejects.toThrow('Tag with this name already exists')
-  })
+      }),
+    ).rejects.toThrow("Tag with this name already exists");
+  });
 
-  it('should update a tag name', async () => {
-    const tag = await createTestTag(env.DB, userId, 'OldName')
+  it("should update a tag name", async () => {
+    const tag = await createTestTag(env.DB, userId, "OldName");
 
-    const updated = await tagRepo.update(env.DB, tag.id, userId, 'NewName')
-    expect(updated.name).toBe('NewName')
-  })
+    const updated = await tagRepo.update(env.DB, tag.id, userId, "NewName");
+    expect(updated.name).toBe("NewName");
+  });
 
-  it('should reject duplicate tag names on update', async () => {
-    const tagA = await createTestTag(env.DB, userId, 'TagA')
-    const tagB = await createTestTag(env.DB, userId, 'TagB')
+  it("should reject duplicate tag names on update", async () => {
+    const tagA = await createTestTag(env.DB, userId, "TagA");
+    const tagB = await createTestTag(env.DB, userId, "TagB");
 
-    await expect(
-      tagRepo.update(env.DB, tagB.id, userId, tagA.name)
-    ).rejects.toThrow('Tag with this name already exists')
-  })
+    await expect(tagRepo.update(env.DB, tagB.id, userId, tagA.name)).rejects.toThrow(
+      "Tag with this name already exists",
+    );
+  });
 
-  it('should delete tag by id', async () => {
-    const tag = await createTestTag(env.DB, userId, 'DeleteMe')
+  it("should delete tag by id", async () => {
+    const tag = await createTestTag(env.DB, userId, "DeleteMe");
 
-    await tagRepo.deleteById(env.DB, tag.id, userId)
+    await tagRepo.deleteById(env.DB, tag.id, userId);
 
-    await expect(
-      tagRepo.findById(env.DB, tag.id, userId)
-    ).rejects.toThrow('Tag not found')
-  })
+    await expect(tagRepo.findById(env.DB, tag.id, userId)).rejects.toThrow("Tag not found");
+  });
 
-  it('should verify tag ownership', async () => {
-    const tag = await createTestTag(env.DB, userId, 'Owned')
-    const otherUser = await createTestUser(env.DB)
+  it("should verify tag ownership", async () => {
+    const tag = await createTestTag(env.DB, userId, "Owned");
+    const otherUser = await createTestUser(env.DB);
 
-    const owned = await tagRepo.belongsToUser(env.DB, tag.id, userId)
-    const notOwned = await tagRepo.belongsToUser(env.DB, tag.id, otherUser.id)
+    const owned = await tagRepo.belongsToUser(env.DB, tag.id, userId);
+    const notOwned = await tagRepo.belongsToUser(env.DB, tag.id, otherUser.id);
 
-    expect(owned).toBe(true)
-    expect(notOwned).toBe(false)
-  })
-})
+    expect(owned).toBe(true);
+    expect(notOwned).toBe(false);
+  });
+});

--- a/app/server/db/repositories/tag.ts
+++ b/app/server/db/repositories/tag.ts
@@ -7,10 +7,7 @@ type D1Database = Env["DB"];
 /**
  * ユーザーのタグ一覧を取得
  */
-export async function findByUserId(
-  db: D1Database,
-  userId: string
-): Promise<Tag[]> {
+export async function findByUserId(db: D1Database, userId: string): Promise<Tag[]> {
   try {
     const result = await db
       .prepare("SELECT * FROM tags WHERE user_id = ? ORDER BY name ASC")
@@ -26,11 +23,7 @@ export async function findByUserId(
 /**
  * IDでタグを取得
  */
-export async function findById(
-  db: D1Database,
-  tagId: string,
-  userId: string
-): Promise<Tag> {
+export async function findById(db: D1Database, tagId: string, userId: string): Promise<Tag> {
   try {
     const result = await db
       .prepare("SELECT * FROM tags WHERE id = ? AND user_id = ?")
@@ -54,7 +47,7 @@ export async function findById(
 export async function findByName(
   db: D1Database,
   name: string,
-  userId: string
+  userId: string,
 ): Promise<Tag | null> {
   try {
     const result = await db
@@ -71,10 +64,7 @@ export async function findByName(
 /**
  * 書籍に紐づくタグ一覧を取得
  */
-export async function findByBookId(
-  db: D1Database,
-  bookId: string
-): Promise<Tag[]> {
+export async function findByBookId(db: D1Database, bookId: string): Promise<Tag[]> {
   try {
     const result = await db
       .prepare(
@@ -83,7 +73,7 @@ export async function findByBookId(
         INNER JOIN book_tags bt ON t.id = bt.tag_id
         WHERE bt.book_id = ?
         ORDER BY t.name ASC
-      `
+      `,
       )
       .bind(bookId)
       .all<Tag>();
@@ -110,7 +100,7 @@ export async function create(db: D1Database, tag: TagInput): Promise<Tag> {
         `
         INSERT INTO tags (id, user_id, name, created_at)
         VALUES (?, ?, ?, ?)
-      `
+      `,
       )
       .bind(tag.id, tag.userId, tag.name, tag.createdAt)
       .run();
@@ -129,7 +119,7 @@ export async function update(
   db: D1Database,
   tagId: string,
   userId: string,
-  name: string
+  name: string,
 ): Promise<Tag> {
   try {
     // タグの存在確認
@@ -148,8 +138,7 @@ export async function update(
 
     return findById(db, tagId, userId);
   } catch (error) {
-    if (error instanceof NotFoundError || error instanceof DatabaseError)
-      throw error;
+    if (error instanceof NotFoundError || error instanceof DatabaseError) throw error;
     throw new DatabaseError("Failed to update tag", error);
   }
 }
@@ -157,20 +146,13 @@ export async function update(
 /**
  * タグを削除
  */
-export async function deleteById(
-  db: D1Database,
-  tagId: string,
-  userId: string
-): Promise<void> {
+export async function deleteById(db: D1Database, tagId: string, userId: string): Promise<void> {
   try {
     // タグの存在確認
     await findById(db, tagId, userId);
 
     // CASCADE削除により関連するbook_tagsも削除される
-    await db
-      .prepare("DELETE FROM tags WHERE id = ? AND user_id = ?")
-      .bind(tagId, userId)
-      .run();
+    await db.prepare("DELETE FROM tags WHERE id = ? AND user_id = ?").bind(tagId, userId).run();
   } catch (error) {
     if (error instanceof NotFoundError) throw error;
     throw new DatabaseError("Failed to delete tag", error);
@@ -183,7 +165,7 @@ export async function deleteById(
 export async function belongsToUser(
   db: D1Database,
   tagId: string,
-  userId: string
+  userId: string,
 ): Promise<boolean> {
   try {
     const result = await db
@@ -196,4 +178,3 @@ export async function belongsToUser(
     throw new DatabaseError("Failed to check tag ownership", error);
   }
 }
-

--- a/app/server/db/repositories/user.test.ts
+++ b/app/server/db/repositories/user.test.ts
@@ -1,128 +1,122 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { env } from 'cloudflare:test'
-import * as userRepo from './user'
-import { createTestUser, cleanupDatabase } from '../../../test/helpers'
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import * as userRepo from "./user";
+import { createTestUser, cleanupDatabase } from "../../../test/helpers";
 
-describe('User Repository', () => {
+describe("User Repository", () => {
   beforeEach(async () => {
-    await cleanupDatabase(env.DB)
-  })
+    await cleanupDatabase(env.DB);
+  });
 
-  it('should find user by id', async () => {
-    const user = await createTestUser(env.DB)
+  it("should find user by id", async () => {
+    const user = await createTestUser(env.DB);
 
-    const found = await userRepo.findById(env.DB, user.id)
-    expect(found.id).toBe(user.id)
-  })
+    const found = await userRepo.findById(env.DB, user.id);
+    expect(found.id).toBe(user.id);
+  });
 
-  it('should throw when user id is missing', async () => {
-    await expect(
-      userRepo.findById(env.DB, 'missing-user-id')
-    ).rejects.toThrow('User not found')
-  })
+  it("should throw when user id is missing", async () => {
+    await expect(userRepo.findById(env.DB, "missing-user-id")).rejects.toThrow("User not found");
+  });
 
-  it('should find user by username', async () => {
-    const user = await createTestUser(env.DB, { username: 'test_user' })
+  it("should find user by username", async () => {
+    const user = await createTestUser(env.DB, { username: "test_user" });
 
-    const found = await userRepo.findByUsername(env.DB, 'test_user')
-    expect(found.id).toBe(user.id)
-  })
+    const found = await userRepo.findByUsername(env.DB, "test_user");
+    expect(found.id).toBe(user.id);
+  });
 
-  it('should throw when username is missing', async () => {
-    await expect(
-      userRepo.findByUsername(env.DB, 'missing_user')
-    ).rejects.toThrow('User not found')
-  })
+  it("should throw when username is missing", async () => {
+    await expect(userRepo.findByUsername(env.DB, "missing_user")).rejects.toThrow("User not found");
+  });
 
-  it('should return null for missing email', async () => {
-    const result = await userRepo.findByEmail(env.DB, 'missing@example.com')
-    expect(result).toBeNull()
-  })
+  it("should return null for missing email", async () => {
+    const result = await userRepo.findByEmail(env.DB, "missing@example.com");
+    expect(result).toBeNull();
+  });
 
-  it('should return null for missing provider', async () => {
-    const result = await userRepo.findByProvider(env.DB, 'github', 'missing')
-    expect(result).toBeNull()
-  })
+  it("should return null for missing provider", async () => {
+    const result = await userRepo.findByProvider(env.DB, "github", "missing");
+    expect(result).toBeNull();
+  });
 
-  it('should report username availability', async () => {
-    const user = await createTestUser(env.DB, { username: 'taken' })
+  it("should report username availability", async () => {
+    const user = await createTestUser(env.DB, { username: "taken" });
 
-    const taken = await userRepo.isUsernameTaken(env.DB, 'taken')
-    const available = await userRepo.isUsernameTaken(env.DB, 'available')
-    const excluded = await userRepo.isUsernameTaken(env.DB, 'taken', user.id)
+    const taken = await userRepo.isUsernameTaken(env.DB, "taken");
+    const available = await userRepo.isUsernameTaken(env.DB, "available");
+    const excluded = await userRepo.isUsernameTaken(env.DB, "taken", user.id);
 
-    expect(taken).toBe(true)
-    expect(available).toBe(false)
-    expect(excluded).toBe(false)
-  })
+    expect(taken).toBe(true);
+    expect(available).toBe(false);
+    expect(excluded).toBe(false);
+  });
 
-  it('should create a new user', async () => {
-    const now = new Date().toISOString()
+  it("should create a new user", async () => {
+    const now = new Date().toISOString();
     const created = await userRepo.create(env.DB, {
-      id: 'user-1',
-      username: 'new_user',
-      email: 'new_user@example.com',
-      name: 'New User',
+      id: "user-1",
+      username: "new_user",
+      email: "new_user@example.com",
+      name: "New User",
       bio: null,
       avatar_url: null,
-      provider: 'github',
-      provider_id: 'provider-1',
+      provider: "github",
+      provider_id: "provider-1",
       created_at: now,
       updated_at: now,
-    })
+    });
 
-    expect(created.username).toBe('new_user')
-    expect(created.email).toBe('new_user@example.com')
-  })
+    expect(created.username).toBe("new_user");
+    expect(created.email).toBe("new_user@example.com");
+  });
 
-  it('should reject duplicate usernames on create', async () => {
-    await createTestUser(env.DB, { username: 'dupe' })
-    const now = new Date().toISOString()
+  it("should reject duplicate usernames on create", async () => {
+    await createTestUser(env.DB, { username: "dupe" });
+    const now = new Date().toISOString();
 
     await expect(
       userRepo.create(env.DB, {
-        id: 'user-2',
-        username: 'dupe',
-        email: 'dupe@example.com',
-        name: 'Dupe',
+        id: "user-2",
+        username: "dupe",
+        email: "dupe@example.com",
+        name: "Dupe",
         bio: null,
         avatar_url: null,
-        provider: 'github',
-        provider_id: 'provider-2',
+        provider: "github",
+        provider_id: "provider-2",
         created_at: now,
         updated_at: now,
-      })
-    ).rejects.toThrow('Username already taken')
-  })
+      }),
+    ).rejects.toThrow("Username already taken");
+  });
 
-  it('should update user fields', async () => {
-    const user = await createTestUser(env.DB, { username: 'before' })
+  it("should update user fields", async () => {
+    const user = await createTestUser(env.DB, { username: "before" });
 
     const updated = await userRepo.update(env.DB, user.id, {
-      username: 'after',
-      name: 'After Name',
-    })
+      username: "after",
+      name: "After Name",
+    });
 
-    expect(updated.username).toBe('after')
-    expect(updated.name).toBe('After Name')
-  })
+    expect(updated.username).toBe("after");
+    expect(updated.name).toBe("After Name");
+  });
 
-  it('should reject duplicate usernames on update', async () => {
-    await createTestUser(env.DB, { username: 'existing' })
-    const user = await createTestUser(env.DB, { username: 'change_me' })
+  it("should reject duplicate usernames on update", async () => {
+    await createTestUser(env.DB, { username: "existing" });
+    const user = await createTestUser(env.DB, { username: "change_me" });
 
-    await expect(
-      userRepo.update(env.DB, user.id, { username: 'existing' })
-    ).rejects.toThrow('Username already taken')
-  })
+    await expect(userRepo.update(env.DB, user.id, { username: "existing" })).rejects.toThrow(
+      "Username already taken",
+    );
+  });
 
-  it('should delete user by id', async () => {
-    const user = await createTestUser(env.DB)
+  it("should delete user by id", async () => {
+    const user = await createTestUser(env.DB);
 
-    await userRepo.deleteById(env.DB, user.id)
+    await userRepo.deleteById(env.DB, user.id);
 
-    await expect(
-      userRepo.findById(env.DB, user.id)
-    ).rejects.toThrow('User not found')
-  })
-})
+    await expect(userRepo.findById(env.DB, user.id)).rejects.toThrow("User not found");
+  });
+});

--- a/app/server/db/repositories/user.ts
+++ b/app/server/db/repositories/user.ts
@@ -10,10 +10,7 @@ type D1BindValue = string | number | null;
  */
 export async function findById(db: D1Database, userId: string): Promise<User> {
   try {
-    const result = await db
-      .prepare("SELECT * FROM users WHERE id = ?")
-      .bind(userId)
-      .first<User>();
+    const result = await db.prepare("SELECT * FROM users WHERE id = ?").bind(userId).first<User>();
 
     if (!result) {
       throw new NotFoundError("User not found");
@@ -29,10 +26,7 @@ export async function findById(db: D1Database, userId: string): Promise<User> {
 /**
  * ユーザー名でユーザーを取得
  */
-export async function findByUsername(
-  db: D1Database,
-  username: string
-): Promise<User> {
+export async function findByUsername(db: D1Database, username: string): Promise<User> {
   try {
     const result = await db
       .prepare("SELECT * FROM users WHERE username = ?")
@@ -53,10 +47,7 @@ export async function findByUsername(
 /**
  * メールアドレスでユーザーを取得
  */
-export async function findByEmail(
-  db: D1Database,
-  email: string
-): Promise<User | null> {
+export async function findByEmail(db: D1Database, email: string): Promise<User | null> {
   try {
     const result = await db
       .prepare("SELECT * FROM users WHERE email = ?")
@@ -75,7 +66,7 @@ export async function findByEmail(
 export async function findByProvider(
   db: D1Database,
   provider: "github" | "google",
-  providerId: string
+  providerId: string,
 ): Promise<User | null> {
   try {
     const result = await db
@@ -95,7 +86,7 @@ export async function findByProvider(
 export async function isUsernameTaken(
   db: D1Database,
   username: string,
-  excludeUserId?: string
+  excludeUserId?: string,
 ): Promise<boolean> {
   try {
     let query = "SELECT id FROM users WHERE username = ?";
@@ -135,7 +126,7 @@ export async function create(db: D1Database, user: UserInput): Promise<User> {
           id, username, email, name, bio, avatar_url,
           provider, provider_id, created_at, updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `
+      `,
       )
       .bind(
         user.id,
@@ -147,7 +138,7 @@ export async function create(db: D1Database, user: UserInput): Promise<User> {
         user.provider,
         user.provider_id,
         user.created_at,
-        user.updated_at
+        user.updated_at,
       )
       .run();
 
@@ -164,7 +155,7 @@ export async function create(db: D1Database, user: UserInput): Promise<User> {
 export async function update(
   db: D1Database,
   userId: string,
-  data: Partial<UserInput>
+  data: Partial<UserInput>,
 ): Promise<User> {
   try {
     // ユーザーの存在確認
@@ -185,18 +176,15 @@ export async function update(
       ["avatar_url", data.avatar_url],
     ] satisfies Array<[string, D1BindValue | undefined]>;
 
-    const definedUpdates = updates.filter(
-      ([, value]) => value !== undefined
-    ) as Array<[string, D1BindValue]>;
+    const definedUpdates = updates.filter(([, value]) => value !== undefined) as Array<
+      [string, D1BindValue]
+    >;
 
     if (definedUpdates.length === 0) {
       return findById(db, userId);
     }
 
-    const fields = [
-      ...definedUpdates.map(([field]) => `${field} = ?`),
-      "updated_at = ?",
-    ];
+    const fields = [...definedUpdates.map(([field]) => `${field} = ?`), "updated_at = ?"];
     const params: D1BindValue[] = [
       ...definedUpdates.map(([, value]) => value),
       new Date().toISOString(),
@@ -209,15 +197,14 @@ export async function update(
         UPDATE users 
         SET ${fields.join(", ")}
         WHERE id = ?
-      `
+      `,
       )
       .bind(...params)
       .run();
 
     return findById(db, userId);
   } catch (error) {
-    if (error instanceof NotFoundError || error instanceof DatabaseError)
-      throw error;
+    if (error instanceof NotFoundError || error instanceof DatabaseError) throw error;
     throw new DatabaseError("Failed to update user", error);
   }
 }
@@ -225,10 +212,7 @@ export async function update(
 /**
  * ユーザーを削除
  */
-export async function deleteById(
-  db: D1Database,
-  userId: string
-): Promise<void> {
+export async function deleteById(db: D1Database, userId: string): Promise<void> {
   try {
     // ユーザーの存在確認
     await findById(db, userId);
@@ -240,4 +224,3 @@ export async function deleteById(
     throw new DatabaseError("Failed to delete user", error);
   }
 }
-

--- a/app/server/db/schema.ts
+++ b/app/server/db/schema.ts
@@ -130,7 +130,7 @@ export async function seedDatabase(db: D1Database): Promise<void> {
       `
     INSERT OR IGNORE INTO users (id, username, email, name, bio, avatar_url, provider, provider_id, created_at, updated_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `
+  `,
     )
     .bind(
       "user-1",
@@ -142,7 +142,7 @@ export async function seedDatabase(db: D1Database): Promise<void> {
       "github",
       "12345",
       now,
-      now
+      now,
     )
     .run();
 
@@ -155,7 +155,7 @@ export async function seedDatabase(db: D1Database): Promise<void> {
       page_count, description, thumbnail_url, status, current_page,
       memo, created_at, updated_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `
+  `,
     )
     .bind(
       "book-1",
@@ -172,7 +172,7 @@ export async function seedDatabase(db: D1Database): Promise<void> {
       120,
       "第3章まで読了。命名規則が参考になる",
       now,
-      now
+      now,
     )
     .run();
 
@@ -184,7 +184,7 @@ export async function seedDatabase(db: D1Database): Promise<void> {
       page_count, description, thumbnail_url, status, current_page,
       created_at, updated_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `
+  `,
     )
     .bind(
       "book-2",
@@ -200,7 +200,7 @@ export async function seedDatabase(db: D1Database): Promise<void> {
       "completed",
       528,
       now,
-      now
+      now,
     )
     .run();
 
@@ -210,7 +210,7 @@ export async function seedDatabase(db: D1Database): Promise<void> {
       `
     INSERT OR IGNORE INTO tags (id, user_id, name, created_at)
     VALUES (?, ?, ?, ?)
-  `
+  `,
     )
     .bind("tag-1", "user-1", "設計", now)
     .run();
@@ -220,7 +220,7 @@ export async function seedDatabase(db: D1Database): Promise<void> {
       `
     INSERT OR IGNORE INTO tags (id, user_id, name, created_at)
     VALUES (?, ?, ?, ?)
-  `
+  `,
     )
     .bind("tag-2", "user-1", "データベース", now)
     .run();
@@ -231,7 +231,7 @@ export async function seedDatabase(db: D1Database): Promise<void> {
       `
     INSERT OR IGNORE INTO book_tags (book_id, tag_id)
     VALUES (?, ?)
-  `
+  `,
     )
     .bind("book-1", "tag-1")
     .run();
@@ -241,9 +241,8 @@ export async function seedDatabase(db: D1Database): Promise<void> {
       `
     INSERT OR IGNORE INTO book_tags (book_id, tag_id)
     VALUES (?, ?)
-  `
+  `,
     )
     .bind("book-2", "tag-2")
     .run();
 }
-

--- a/app/server/domain/book.test.ts
+++ b/app/server/domain/book.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from "vitest";
 import {
   calculateStatus,
   calculateProgress,
@@ -6,110 +6,110 @@ import {
   isCompleted,
   isReading,
   shouldSetFinishedAt,
-} from './book'
+} from "./book";
 
-describe('calculateStatus', () => {
+describe("calculateStatus", () => {
   it('should return "unread" when currentPage is 0', () => {
-    expect(calculateStatus(0, 100)).toBe('unread')
-    expect(calculateStatus(0, 0)).toBe('unread')
-  })
+    expect(calculateStatus(0, 100)).toBe("unread");
+    expect(calculateStatus(0, 0)).toBe("unread");
+  });
 
   it('should return "completed" when currentPage >= pageCount', () => {
-    expect(calculateStatus(100, 100)).toBe('completed')
-    expect(calculateStatus(150, 100)).toBe('completed')
-  })
+    expect(calculateStatus(100, 100)).toBe("completed");
+    expect(calculateStatus(150, 100)).toBe("completed");
+  });
 
   it('should return "reading" when in progress', () => {
-    expect(calculateStatus(50, 100)).toBe('reading')
-    expect(calculateStatus(1, 100)).toBe('reading')
-    expect(calculateStatus(99, 100)).toBe('reading')
-  })
+    expect(calculateStatus(50, 100)).toBe("reading");
+    expect(calculateStatus(1, 100)).toBe("reading");
+    expect(calculateStatus(99, 100)).toBe("reading");
+  });
 
   it('should return "reading" when pageCount is 0 but currentPage > 0', () => {
-    expect(calculateStatus(50, 0)).toBe('reading')
-  })
-})
+    expect(calculateStatus(50, 0)).toBe("reading");
+  });
+});
 
-describe('calculateProgress', () => {
-  it('should return 0 when pageCount is 0', () => {
-    expect(calculateProgress(50, 0)).toBe(0)
-    expect(calculateProgress(0, 0)).toBe(0)
-  })
+describe("calculateProgress", () => {
+  it("should return 0 when pageCount is 0", () => {
+    expect(calculateProgress(50, 0)).toBe(0);
+    expect(calculateProgress(0, 0)).toBe(0);
+  });
 
-  it('should calculate progress percentage correctly', () => {
-    expect(calculateProgress(50, 100)).toBe(50)
-    expect(calculateProgress(25, 100)).toBe(25)
-    expect(calculateProgress(1, 3)).toBe(33)
-  })
+  it("should calculate progress percentage correctly", () => {
+    expect(calculateProgress(50, 100)).toBe(50);
+    expect(calculateProgress(25, 100)).toBe(25);
+    expect(calculateProgress(1, 3)).toBe(33);
+  });
 
-  it('should cap at 100%', () => {
-    expect(calculateProgress(150, 100)).toBe(100)
-    expect(calculateProgress(100, 100)).toBe(100)
-  })
+  it("should cap at 100%", () => {
+    expect(calculateProgress(150, 100)).toBe(100);
+    expect(calculateProgress(100, 100)).toBe(100);
+  });
 
-  it('should return 0 when currentPage is 0', () => {
-    expect(calculateProgress(0, 100)).toBe(0)
-  })
-})
+  it("should return 0 when currentPage is 0", () => {
+    expect(calculateProgress(0, 100)).toBe(0);
+  });
+});
 
-describe('validatePageProgress', () => {
-  it('should return valid for normal progress', () => {
-    expect(validatePageProgress(50, 100)).toEqual({ valid: true })
-    expect(validatePageProgress(0, 100)).toEqual({ valid: true })
-    expect(validatePageProgress(100, 100)).toEqual({ valid: true })
-  })
+describe("validatePageProgress", () => {
+  it("should return valid for normal progress", () => {
+    expect(validatePageProgress(50, 100)).toEqual({ valid: true });
+    expect(validatePageProgress(0, 100)).toEqual({ valid: true });
+    expect(validatePageProgress(100, 100)).toEqual({ valid: true });
+  });
 
-  it('should return invalid for negative currentPage', () => {
-    const result = validatePageProgress(-1, 100)
-    expect(result.valid).toBe(false)
-    expect(result.error).toBe('Current page cannot be negative')
-  })
+  it("should return invalid for negative currentPage", () => {
+    const result = validatePageProgress(-1, 100);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Current page cannot be negative");
+  });
 
-  it('should return invalid when currentPage exceeds pageCount', () => {
-    const result = validatePageProgress(150, 100)
-    expect(result.valid).toBe(false)
-    expect(result.error).toBe('Current page exceeds total pages')
-  })
+  it("should return invalid when currentPage exceeds pageCount", () => {
+    const result = validatePageProgress(150, 100);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Current page exceeds total pages");
+  });
 
-  it('should allow any currentPage when pageCount is 0', () => {
-    expect(validatePageProgress(50, 0)).toEqual({ valid: true })
-  })
-})
+  it("should allow any currentPage when pageCount is 0", () => {
+    expect(validatePageProgress(50, 0)).toEqual({ valid: true });
+  });
+});
 
-describe('isCompleted', () => {
-  it('should return true for completed status', () => {
-    expect(isCompleted('completed')).toBe(true)
-  })
+describe("isCompleted", () => {
+  it("should return true for completed status", () => {
+    expect(isCompleted("completed")).toBe(true);
+  });
 
-  it('should return false for other statuses', () => {
-    expect(isCompleted('unread')).toBe(false)
-    expect(isCompleted('reading')).toBe(false)
-  })
-})
+  it("should return false for other statuses", () => {
+    expect(isCompleted("unread")).toBe(false);
+    expect(isCompleted("reading")).toBe(false);
+  });
+});
 
-describe('isReading', () => {
-  it('should return true for reading status', () => {
-    expect(isReading('reading')).toBe(true)
-  })
+describe("isReading", () => {
+  it("should return true for reading status", () => {
+    expect(isReading("reading")).toBe(true);
+  });
 
-  it('should return false for other statuses', () => {
-    expect(isReading('unread')).toBe(false)
-    expect(isReading('completed')).toBe(false)
-  })
-})
+  it("should return false for other statuses", () => {
+    expect(isReading("unread")).toBe(false);
+    expect(isReading("completed")).toBe(false);
+  });
+});
 
-describe('shouldSetFinishedAt', () => {
-  it('should return true when transitioning to completed', () => {
-    expect(shouldSetFinishedAt('completed', 'reading')).toBe(true)
-    expect(shouldSetFinishedAt('completed', 'unread')).toBe(true)
-  })
+describe("shouldSetFinishedAt", () => {
+  it("should return true when transitioning to completed", () => {
+    expect(shouldSetFinishedAt("completed", "reading")).toBe(true);
+    expect(shouldSetFinishedAt("completed", "unread")).toBe(true);
+  });
 
-  it('should return false when already completed', () => {
-    expect(shouldSetFinishedAt('completed', 'completed')).toBe(false)
-  })
+  it("should return false when already completed", () => {
+    expect(shouldSetFinishedAt("completed", "completed")).toBe(false);
+  });
 
-  it('should return false when not transitioning to completed', () => {
-    expect(shouldSetFinishedAt('reading', 'unread')).toBe(false)
-    expect(shouldSetFinishedAt('unread', 'reading')).toBe(false)
-  })
-})
+  it("should return false when not transitioning to completed", () => {
+    expect(shouldSetFinishedAt("reading", "unread")).toBe(false);
+    expect(shouldSetFinishedAt("unread", "reading")).toBe(false);
+  });
+});

--- a/app/server/domain/book.ts
+++ b/app/server/domain/book.ts
@@ -3,10 +3,7 @@ import type { BookStatus } from "../../types/database";
 /**
  * 進捗に基づいてステータスを計算
  */
-export function calculateStatus(
-  currentPage: number,
-  pageCount: number
-): BookStatus {
+export function calculateStatus(currentPage: number, pageCount: number): BookStatus {
   if (currentPage === 0) return "unread";
   if (pageCount > 0 && currentPage >= pageCount) return "completed";
   return "reading";
@@ -15,10 +12,7 @@ export function calculateStatus(
 /**
  * 進捗率を計算（0-100）
  */
-export function calculateProgress(
-  currentPage: number,
-  pageCount: number
-): number {
+export function calculateProgress(currentPage: number, pageCount: number): number {
   if (pageCount === 0) return 0;
   return Math.min(100, Math.round((currentPage / pageCount) * 100));
 }
@@ -28,7 +22,7 @@ export function calculateProgress(
  */
 export function validatePageProgress(
   currentPage: number,
-  pageCount: number
+  pageCount: number,
 ): { valid: boolean; error?: string } {
   if (currentPage < 0) {
     return { valid: false, error: "Current page cannot be negative" };
@@ -56,10 +50,6 @@ export function isReading(status: BookStatus): boolean {
 /**
  * 読了日を設定すべきか判定
  */
-export function shouldSetFinishedAt(
-  newStatus: BookStatus,
-  oldStatus: BookStatus
-): boolean {
+export function shouldSetFinishedAt(newStatus: BookStatus, oldStatus: BookStatus): boolean {
   return newStatus === "completed" && oldStatus !== "completed";
 }
-

--- a/app/server/domain/index.ts
+++ b/app/server/domain/index.ts
@@ -1,3 +1,1 @@
 export * as bookDomain from "./book";
-
-

--- a/app/server/lib/auth.test.ts
+++ b/app/server/lib/auth.test.ts
@@ -1,81 +1,75 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { Hono } from 'hono'
-import { env } from 'cloudflare:test'
-import { authMiddleware, optionalAuthMiddleware, invalidateUserCache } from './auth'
-import { createTestSession, createTestUser, cleanupDatabase } from '../../test/helpers'
-import type { HonoContext } from '../../types/env'
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import { env } from "cloudflare:test";
+import { authMiddleware, optionalAuthMiddleware, invalidateUserCache } from "./auth";
+import { createTestSession, createTestUser, cleanupDatabase } from "../../test/helpers";
+import type { HonoContext } from "../../types/env";
 
-describe('Auth middleware', () => {
-  const warnSpy = vi.spyOn(console, 'warn')
+describe("Auth middleware", () => {
+  const warnSpy = vi.spyOn(console, "warn");
 
   beforeEach(async () => {
-    warnSpy.mockImplementation(() => {})
-    await cleanupDatabase(env.DB)
-  })
+    warnSpy.mockImplementation(() => {});
+    await cleanupDatabase(env.DB);
+  });
 
-  it('should return 401 without session cookie', async () => {
-    const app = new Hono<HonoContext>()
-    app.use('*', authMiddleware)
-    app.get('/protected', (c) => c.json({ ok: true }))
+  it("should return 401 without session cookie", async () => {
+    const app = new Hono<HonoContext>();
+    app.use("*", authMiddleware);
+    app.get("/protected", (c) => c.json({ ok: true }));
 
-    const res = await app.request('/protected', {}, env)
-    expect(res.status).toBe(401)
-  })
+    const res = await app.request("/protected", {}, env);
+    expect(res.status).toBe(401);
+  });
 
-  it('should set user info for valid session', async () => {
-    const user = await createTestUser(env.DB)
-    const sessionId = await createTestSession(env.KV, user.id)
+  it("should set user info for valid session", async () => {
+    const user = await createTestUser(env.DB);
+    const sessionId = await createTestSession(env.KV, user.id);
 
-    const app = new Hono<HonoContext>()
-    app.use('*', authMiddleware)
-    app.get('/protected', (c) =>
-      c.json({ userId: c.get('userId'), user: c.get('user') })
-    )
+    const app = new Hono<HonoContext>();
+    app.use("*", authMiddleware);
+    app.get("/protected", (c) => c.json({ userId: c.get("userId"), user: c.get("user") }));
 
     const res = await app.request(
-      '/protected',
+      "/protected",
       { headers: { Cookie: `session_id=${sessionId}` } },
-      env
-    )
+      env,
+    );
 
-    expect(res.status).toBe(200)
-    const body = await res.json() as { userId: string; user: { id: string } }
-    expect(body.userId).toBe(user.id)
-    expect(body.user.id).toBe(user.id)
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { userId: string; user: { id: string } };
+    expect(body.userId).toBe(user.id);
+    expect(body.user.id).toBe(user.id);
 
-    const cached = await env.KV.get(`user_cache:${user.id}`)
-    expect(cached).toBeTruthy()
-  })
+    const cached = await env.KV.get(`user_cache:${user.id}`);
+    expect(cached).toBeTruthy();
+  });
 
-  it('should allow optional auth without session', async () => {
-    const app = new Hono<HonoContext>()
-    app.use('*', optionalAuthMiddleware)
-    app.get('/optional', (c) => c.json({ userId: c.get('userId') ?? null }))
+  it("should allow optional auth without session", async () => {
+    const app = new Hono<HonoContext>();
+    app.use("*", optionalAuthMiddleware);
+    app.get("/optional", (c) => c.json({ userId: c.get("userId") ?? null }));
 
-    const res = await app.request('/optional', {}, env)
-    expect(res.status).toBe(200)
-    const body = await res.json() as { userId: string | null }
-    expect(body.userId).toBeNull()
-  })
+    const res = await app.request("/optional", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { userId: string | null };
+    expect(body.userId).toBeNull();
+  });
 
-  it('should ignore invalid session in optional auth', async () => {
-    const app = new Hono<HonoContext>()
-    app.use('*', optionalAuthMiddleware)
-    app.get('/optional', (c) => c.json({ userId: c.get('userId') ?? null }))
+  it("should ignore invalid session in optional auth", async () => {
+    const app = new Hono<HonoContext>();
+    app.use("*", optionalAuthMiddleware);
+    app.get("/optional", (c) => c.json({ userId: c.get("userId") ?? null }));
 
-    const res = await app.request(
-      '/optional',
-      { headers: { Cookie: 'session_id=missing' } },
-      env
-    )
-    expect(res.status).toBe(200)
-    expect(warnSpy).toHaveBeenCalled()
-  })
+    const res = await app.request("/optional", { headers: { Cookie: "session_id=missing" } }, env);
+    expect(res.status).toBe(200);
+    expect(warnSpy).toHaveBeenCalled();
+  });
 
-  it('should invalidate cached user', async () => {
-    await env.KV.put('user_cache:user-1', JSON.stringify({ id: 'user-1' }))
-    await invalidateUserCache(env.KV, 'user-1')
-    const cached = await env.KV.get('user_cache:user-1')
-    expect(cached).toBeNull()
-  })
-})
+  it("should invalidate cached user", async () => {
+    await env.KV.put("user_cache:user-1", JSON.stringify({ id: "user-1" }));
+    await invalidateUserCache(env.KV, "user-1");
+    const cached = await env.KV.get("user_cache:user-1");
+    expect(cached).toBeNull();
+  });
+});

--- a/app/server/lib/auth.ts
+++ b/app/server/lib/auth.ts
@@ -14,10 +14,7 @@ const USER_CACHE_TTL = 300; // 5分
 /**
  * キャッシュからユーザー情報を取得
  */
-async function getCachedUser(
-  kv: KVNamespace,
-  userId: string
-): Promise<User | null> {
+async function getCachedUser(kv: KVNamespace, userId: string): Promise<User | null> {
   try {
     const cached = await kv.get(`user_cache:${userId}`);
     if (cached) {
@@ -45,10 +42,7 @@ async function setCachedUser(kv: KVNamespace, user: User): Promise<void> {
 /**
  * ユーザーキャッシュを無効化
  */
-export async function invalidateUserCache(
-  kv: KVNamespace,
-  userId: string
-): Promise<void> {
+export async function invalidateUserCache(kv: KVNamespace, userId: string): Promise<void> {
   try {
     await kv.delete(`user_cache:${userId}`);
   } catch {
@@ -61,7 +55,7 @@ export async function invalidateUserCache(
  */
 export async function authMiddleware(
   c: Context<HonoContext>,
-  next: Next
+  next: Next,
 ): Promise<Response | void> {
   try {
     const sessionId = getCookie(c, "session_id");
@@ -97,7 +91,7 @@ export async function authMiddleware(
             code: "UNAUTHORIZED",
           },
         },
-        401
+        401,
       );
     }
 
@@ -108,10 +102,7 @@ export async function authMiddleware(
 /**
  * オプショナル認証ミドルウェア（キャッシュ対応）
  */
-export async function optionalAuthMiddleware(
-  c: Context<HonoContext>,
-  next: Next
-): Promise<void> {
+export async function optionalAuthMiddleware(c: Context<HonoContext>, next: Next): Promise<void> {
   try {
     const sessionId = getCookie(c, "session_id");
 
@@ -141,11 +132,9 @@ export async function optionalAuthMiddleware(
  * 管理者ミドルウェア
  */
 export async function adminMiddleware(
-  c: Context<HonoContext>,
-  next: Next
+  _c: Context<HonoContext>,
+  next: Next,
 ): Promise<Response | void> {
-  const user = c.get("user");
-
   // 将来的に管理者フラグを追加する場合
   // if (!user.isAdmin) {
   //   return c.json({ error: "Forbidden" }, 403);
@@ -159,8 +148,6 @@ export async function adminMiddleware(
  */
 export function checkOwnership(userId: string, resourceUserId: string): void {
   if (userId !== resourceUserId) {
-    throw new UnauthorizedError(
-      "You don't have permission to access this resource"
-    );
+    throw new UnauthorizedError("You don't have permission to access this resource");
   }
 }

--- a/app/server/lib/errors.ts
+++ b/app/server/lib/errors.ts
@@ -10,7 +10,7 @@ export class AppError extends Error {
     message: string,
     statusCode: number = 500,
     public code?: string,
-    public details?: unknown
+    public details?: unknown,
   ) {
     super(message);
     this.name = "AppError";
@@ -79,7 +79,7 @@ export class ExternalApiError extends AppError {
   constructor(
     message: string = "External API error",
     public apiName?: string,
-    cause?: unknown
+    cause?: unknown,
   ) {
     super(message, 502, "EXTERNAL_API_ERROR", cause);
     this.name = "ExternalApiError";
@@ -136,12 +136,10 @@ export function errorHandler(err: Error, c: Context) {
         error: {
           message: err.message,
           code: err.code,
-          ...(shouldExposeDetails && err.details
-            ? { details: err.details }
-            : {}),
+          ...(shouldExposeDetails && err.details ? { details: err.details } : {}),
         },
       },
-      err.statusCode as 400 | 401 | 403 | 404 | 429 | 500 | 502
+      err.statusCode as 400 | 401 | 403 | 404 | 429 | 500 | 502,
     );
   }
 
@@ -154,6 +152,6 @@ export function errorHandler(err: Error, c: Context) {
         code: "INTERNAL_ERROR",
       },
     },
-    500
+    500,
   );
 }

--- a/app/server/lib/mapper.ts
+++ b/app/server/lib/mapper.ts
@@ -15,10 +15,7 @@ import { removeUndefined } from "./utils";
 /**
  * API入力からBookInputへ変換
  */
-export function toBookInput(
-  data: CreateBookInput,
-  userId: string
-): BookInput {
+export function toBookInput(data: CreateBookInput, userId: string): BookInput {
   const now = new Date().toISOString();
   return {
     id: crypto.randomUUID(),
@@ -44,9 +41,7 @@ export function toBookInput(
 /**
  * 更新用のBookInputへ変換
  */
-export function toBookUpdateInput(
-  data: UpdateBookInput
-): Partial<BookInput> {
+export function toBookUpdateInput(data: UpdateBookInput): Partial<BookInput> {
   return removeUndefined({
     updatedAt: new Date().toISOString(),
     title: data.title,
@@ -95,10 +90,7 @@ export function toBookResponse(book: Book): BookResponse {
 /**
  * API入力からTagInputへ変換
  */
-export function toTagInput(
-  data: CreateTagInput,
-  userId: string
-): TagInput {
+export function toTagInput(data: CreateTagInput, userId: string): TagInput {
   return {
     id: crypto.randomUUID(),
     userId,
@@ -135,5 +127,3 @@ export function toUserResponse(user: User): UserResponse {
     updatedAt: user.updated_at,
   };
 }
-
-

--- a/app/server/lib/rate-limit.test.ts
+++ b/app/server/lib/rate-limit.test.ts
@@ -1,49 +1,49 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { Hono } from 'hono'
-import { env } from 'cloudflare:test'
-import { rateLimiter } from './rate-limit'
-import { errorHandler } from './errors'
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { env } from "cloudflare:test";
+import { rateLimiter } from "./rate-limit";
+import { errorHandler } from "./errors";
 
-describe('rateLimiter middleware', () => {
-  const errorSpy = vi.spyOn(console, 'error')
+describe("rateLimiter middleware", () => {
+  const errorSpy = vi.spyOn(console, "error");
 
   beforeEach(() => {
-    errorSpy.mockImplementation(() => {})
-  })
+    errorSpy.mockImplementation(() => {});
+  });
 
   afterEach(() => {
-    errorSpy.mockReset()
-  })
+    errorSpy.mockReset();
+  });
 
-  it('should enforce limits per window', async () => {
-    const app = new Hono()
-    app.onError(errorHandler)
+  it("should enforce limits per window", async () => {
+    const app = new Hono();
+    app.onError(errorHandler);
     app.use(
-      '*',
+      "*",
       rateLimiter({
         windowSec: 60,
         limit: 1,
-        keyPrefix: 'test',
-      })
-    )
-    app.get('/limited', (c) => c.json({ ok: true }))
+        keyPrefix: "test",
+      }),
+    );
+    app.get("/limited", (c) => c.json({ ok: true }));
 
     const first = await app.request(
-      '/limited',
-      { headers: { 'CF-Connecting-IP': '1.1.1.1' } },
-      env
-    )
-    expect(first.status).toBe(200)
-    expect(first.headers.get('X-RateLimit-Limit')).toBe('1')
-    expect(first.headers.get('X-RateLimit-Remaining')).toBe('0')
+      "/limited",
+      { headers: { "CF-Connecting-IP": "1.1.1.1" } },
+      env,
+    );
+    expect(first.status).toBe(200);
+    expect(first.headers.get("X-RateLimit-Limit")).toBe("1");
+    expect(first.headers.get("X-RateLimit-Remaining")).toBe("0");
 
     const second = await app.request(
-      '/limited',
-      { headers: { 'CF-Connecting-IP': '1.1.1.1' } },
-      env
-    )
-    expect(second.status).toBe(429)
-    expect(second.headers.get('Retry-After')).toBeTruthy()
-    expect(errorSpy).toHaveBeenCalled()
-  })
-})
+      "/limited",
+      { headers: { "CF-Connecting-IP": "1.1.1.1" } },
+      env,
+    );
+    expect(second.status).toBe(429);
+    expect(second.headers.get("Retry-After")).toBeTruthy();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/app/server/lib/rate-limit.ts
+++ b/app/server/lib/rate-limit.ts
@@ -23,15 +23,8 @@ interface RateLimitEntry {
 /**
  * レートリミット用ミドルウェア
  */
-export function rateLimiter(
-  config: RateLimitConfig
-): MiddlewareHandler<HonoContext> {
-  const {
-    windowSec,
-    limit,
-    keyPrefix,
-    keyGenerator = defaultKeyGenerator,
-  } = config;
+export function rateLimiter(config: RateLimitConfig): MiddlewareHandler<HonoContext> {
+  const { windowSec, limit, keyPrefix, keyGenerator = defaultKeyGenerator } = config;
 
   return async (c: Context<HonoContext>, next: Next) => {
     const kv = c.env.KV;
@@ -73,10 +66,7 @@ export function rateLimiter(
     // 制限を超えている場合
     if (entry.count > limit) {
       c.header("Retry-After", String(retryAfter));
-      throw new RateLimitError(
-        "Too many requests. Please try again later.",
-        retryAfter
-      );
+      throw new RateLimitError("Too many requests. Please try again later.", retryAfter);
     }
 
     // エントリを更新（TTLをウィンドウサイズに設定）

--- a/app/server/lib/response.ts
+++ b/app/server/lib/response.ts
@@ -43,14 +43,14 @@ export interface PaginatedResponse<T> {
 export function successResponse<T, S extends ContentfulStatusCode = 200>(
   c: Context,
   data: T,
-  status?: S
+  status?: S,
 ) {
   return c.json<SuccessResponse<T>, S>(
     {
       success: true,
       data,
     },
-    (status ?? 200) as S
+    (status ?? 200) as S,
   );
 }
 
@@ -62,7 +62,7 @@ export function errorResponse<S extends ContentfulStatusCode = 400>(
   message: string,
   code: string,
   status?: S,
-  details?: unknown
+  details?: unknown,
 ) {
   return c.json<ErrorResponse, S>(
     {
@@ -73,7 +73,7 @@ export function errorResponse<S extends ContentfulStatusCode = 400>(
         details,
       },
     },
-    (status ?? 400) as S
+    (status ?? 400) as S,
   );
 }
 
@@ -86,7 +86,7 @@ export function paginatedResponse<T, S extends ContentfulStatusCode = 200>(
   total: number,
   limit: number,
   offset: number,
-  status?: S
+  status?: S,
 ) {
   return c.json<SuccessResponse<PaginatedResponse<T>>, S>(
     {
@@ -99,6 +99,6 @@ export function paginatedResponse<T, S extends ContentfulStatusCode = 200>(
         hasMore: offset + items.length < total,
       },
     },
-    (status ?? 200) as S
+    (status ?? 200) as S,
   );
 }

--- a/app/server/lib/session.test.ts
+++ b/app/server/lib/session.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { env } from 'cloudflare:test'
+import { describe, it, expect } from "vitest";
+import { env } from "cloudflare:test";
 import {
   createSession,
   getSession,
@@ -8,63 +8,59 @@ import {
   refreshSession,
   deleteAllUserSessions,
   regenerateSession,
-} from './session'
+} from "./session";
 
-describe('Session helpers', () => {
-  it('should create and get a session', async () => {
-    const sessionId = await createSession(env.KV, 'user-1')
-    const userId = await getSession(env.KV, sessionId)
-    expect(userId).toBe('user-1')
-  })
+describe("Session helpers", () => {
+  it("should create and get a session", async () => {
+    const sessionId = await createSession(env.KV, "user-1");
+    const userId = await getSession(env.KV, sessionId);
+    expect(userId).toBe("user-1");
+  });
 
-  it('should validate existing session', async () => {
-    const sessionId = await createSession(env.KV, 'user-2')
-    const userId = await validateSession(env.KV, sessionId)
-    expect(userId).toBe('user-2')
-  })
+  it("should validate existing session", async () => {
+    const sessionId = await createSession(env.KV, "user-2");
+    const userId = await validateSession(env.KV, sessionId);
+    expect(userId).toBe("user-2");
+  });
 
-  it('should throw on missing session', async () => {
-    await expect(validateSession(env.KV, 'missing')).rejects.toThrow(
-      'Invalid or expired session'
-    )
-  })
+  it("should throw on missing session", async () => {
+    await expect(validateSession(env.KV, "missing")).rejects.toThrow("Invalid or expired session");
+  });
 
-  it('should delete a session', async () => {
-    const sessionId = await createSession(env.KV, 'user-3')
-    await deleteSession(env.KV, sessionId)
-    const userId = await getSession(env.KV, sessionId)
-    expect(userId).toBeNull()
-  })
+  it("should delete a session", async () => {
+    const sessionId = await createSession(env.KV, "user-3");
+    await deleteSession(env.KV, sessionId);
+    const userId = await getSession(env.KV, sessionId);
+    expect(userId).toBeNull();
+  });
 
-  it('should refresh an existing session', async () => {
-    const sessionId = await createSession(env.KV, 'user-4', 60)
-    await refreshSession(env.KV, sessionId, 60)
-    const userId = await getSession(env.KV, sessionId)
-    expect(userId).toBe('user-4')
-  })
+  it("should refresh an existing session", async () => {
+    const sessionId = await createSession(env.KV, "user-4", 60);
+    await refreshSession(env.KV, sessionId, 60);
+    const userId = await getSession(env.KV, sessionId);
+    expect(userId).toBe("user-4");
+  });
 
-  it('should throw when refreshing missing session', async () => {
-    await expect(refreshSession(env.KV, 'missing')).rejects.toThrow(
-      'Session not found'
-    )
-  })
+  it("should throw when refreshing missing session", async () => {
+    await expect(refreshSession(env.KV, "missing")).rejects.toThrow("Session not found");
+  });
 
-  it('should regenerate session and remove old session', async () => {
-    const oldSessionId = await createSession(env.KV, 'user-5')
-    const newSessionId = await regenerateSession(env.KV, oldSessionId, 'user-5')
+  it("should regenerate session and remove old session", async () => {
+    const oldSessionId = await createSession(env.KV, "user-5");
+    const newSessionId = await regenerateSession(env.KV, oldSessionId, "user-5");
 
-    expect(newSessionId).not.toBe(oldSessionId)
-    expect(await getSession(env.KV, oldSessionId)).toBeNull()
-    expect(await getSession(env.KV, newSessionId)).toBe('user-5')
-  })
+    expect(newSessionId).not.toBe(oldSessionId);
+    expect(await getSession(env.KV, oldSessionId)).toBeNull();
+    expect(await getSession(env.KV, newSessionId)).toBe("user-5");
+  });
 
-  it('should delete all user sessions', async () => {
-    const sessionA = await createSession(env.KV, 'user-6')
-    const sessionB = await createSession(env.KV, 'user-6')
+  it("should delete all user sessions", async () => {
+    const sessionA = await createSession(env.KV, "user-6");
+    const sessionB = await createSession(env.KV, "user-6");
 
-    await deleteAllUserSessions(env.KV, [sessionA, sessionB])
+    await deleteAllUserSessions(env.KV, [sessionA, sessionB]);
 
-    expect(await getSession(env.KV, sessionA)).toBeNull()
-    expect(await getSession(env.KV, sessionB)).toBeNull()
-  })
-})
+    expect(await getSession(env.KV, sessionA)).toBeNull();
+    expect(await getSession(env.KV, sessionB)).toBeNull();
+  });
+});

--- a/app/server/lib/session.ts
+++ b/app/server/lib/session.ts
@@ -24,7 +24,7 @@ export const SESSION_COOKIE_OPTIONS = {
 export async function createSession(
   kv: KVNamespace,
   userId: string,
-  ttl: number = SESSION_TTL
+  ttl: number = SESSION_TTL,
 ): Promise<string> {
   const sessionId = crypto.randomUUID();
   const key = `${SESSION_PREFIX}${sessionId}`;
@@ -39,10 +39,7 @@ export async function createSession(
 /**
  * セッションを取得
  */
-export async function getSession(
-  kv: KVNamespace,
-  sessionId: string
-): Promise<string | null> {
+export async function getSession(kv: KVNamespace, sessionId: string): Promise<string | null> {
   const key = `${SESSION_PREFIX}${sessionId}`;
   return await kv.get(key);
 }
@@ -50,10 +47,7 @@ export async function getSession(
 /**
  * セッションを検証してユーザーIDを取得（存在しない場合はエラー）
  */
-export async function validateSession(
-  kv: KVNamespace,
-  sessionId: string
-): Promise<string> {
+export async function validateSession(kv: KVNamespace, sessionId: string): Promise<string> {
   const userId = await getSession(kv, sessionId);
 
   if (!userId) {
@@ -66,10 +60,7 @@ export async function validateSession(
 /**
  * セッションを削除
  */
-export async function deleteSession(
-  kv: KVNamespace,
-  sessionId: string
-): Promise<void> {
+export async function deleteSession(kv: KVNamespace, sessionId: string): Promise<void> {
   const key = `${SESSION_PREFIX}${sessionId}`;
   await kv.delete(key);
 }
@@ -80,7 +71,7 @@ export async function deleteSession(
 export async function refreshSession(
   kv: KVNamespace,
   sessionId: string,
-  ttl: number = SESSION_TTL
+  ttl: number = SESSION_TTL,
 ): Promise<void> {
   const userId = await getSession(kv, sessionId);
 
@@ -97,13 +88,8 @@ export async function refreshSession(
 /**
  * ユーザーの全セッションを削除（ログアウト時など）
  */
-export async function deleteAllUserSessions(
-  kv: KVNamespace,
-  sessionIds: string[]
-): Promise<void> {
-  const deletePromises = sessionIds.map((sessionId) =>
-    deleteSession(kv, sessionId)
-  );
+export async function deleteAllUserSessions(kv: KVNamespace, sessionIds: string[]): Promise<void> {
+  const deletePromises = sessionIds.map((sessionId) => deleteSession(kv, sessionId));
   await Promise.all(deletePromises);
 }
 
@@ -115,7 +101,7 @@ export async function regenerateSession(
   kv: KVNamespace,
   oldSessionId: string | undefined,
   userId: string,
-  ttl: number = SESSION_TTL
+  ttl: number = SESSION_TTL,
 ): Promise<string> {
   // 既存のセッションがあれば削除
   if (oldSessionId) {

--- a/app/server/lib/utils.test.ts
+++ b/app/server/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from "vitest";
 import {
   generateRandomString,
   removeUndefined,
@@ -9,108 +9,111 @@ import {
   keysToCamel,
   keysToSnake,
   truncate,
-} from './utils'
+} from "./utils";
 
-describe('generateRandomString', () => {
-  it('should generate string of specified length', () => {
-    expect(generateRandomString(16)).toHaveLength(16)
-    expect(generateRandomString(32)).toHaveLength(32)
-    expect(generateRandomString(64)).toHaveLength(64)
-  })
+describe("generateRandomString", () => {
+  it("should generate string of specified length", () => {
+    expect(generateRandomString(16)).toHaveLength(16);
+    expect(generateRandomString(32)).toHaveLength(32);
+    expect(generateRandomString(64)).toHaveLength(64);
+  });
 
-  it('should generate different strings each time', () => {
-    const str1 = generateRandomString(32)
-    const str2 = generateRandomString(32)
-    expect(str1).not.toBe(str2)
-  })
+  it("should generate different strings each time", () => {
+    const str1 = generateRandomString(32);
+    const str2 = generateRandomString(32);
+    expect(str1).not.toBe(str2);
+  });
 
-  it('should only contain alphanumeric characters', () => {
-    const str = generateRandomString(100)
-    expect(str).toMatch(/^[A-Za-z0-9]+$/)
-  })
-})
+  it("should only contain alphanumeric characters", () => {
+    const str = generateRandomString(100);
+    expect(str).toMatch(/^[A-Za-z0-9]+$/);
+  });
+});
 
-describe('removeUndefined', () => {
-  it('should remove undefined properties', () => {
-    const obj = { a: 1, b: undefined, c: 'test' }
-    expect(removeUndefined(obj)).toEqual({ a: 1, c: 'test' })
-  })
+describe("removeUndefined", () => {
+  it("should remove undefined properties", () => {
+    const obj = { a: 1, b: undefined, c: "test" };
+    expect(removeUndefined(obj)).toEqual({ a: 1, c: "test" });
+  });
 
-  it('should keep null and empty string', () => {
-    const obj = { a: null, b: '', c: 0 }
-    expect(removeUndefined(obj)).toEqual({ a: null, b: '', c: 0 })
-  })
+  it("should keep null and empty string", () => {
+    const obj = { a: null, b: "", c: 0 };
+    expect(removeUndefined(obj)).toEqual({ a: null, b: "", c: 0 });
+  });
 
-  it('should return empty object for all undefined', () => {
-    const obj = { a: undefined, b: undefined }
-    expect(removeUndefined(obj)).toEqual({})
-  })
-})
+  it("should return empty object for all undefined", () => {
+    const obj = { a: undefined, b: undefined };
+    expect(removeUndefined(obj)).toEqual({});
+  });
+});
 
-describe('chunk', () => {
-  it('should split array into chunks of specified size', () => {
-    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
-    expect(chunk([1, 2, 3, 4], 2)).toEqual([[1, 2], [3, 4]])
-  })
+describe("chunk", () => {
+  it("should split array into chunks of specified size", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+    expect(chunk([1, 2, 3, 4], 2)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
 
-  it('should return single chunk if size is larger than array', () => {
-    expect(chunk([1, 2], 5)).toEqual([[1, 2]])
-  })
+  it("should return single chunk if size is larger than array", () => {
+    expect(chunk([1, 2], 5)).toEqual([[1, 2]]);
+  });
 
-  it('should return empty array for empty input', () => {
-    expect(chunk([], 2)).toEqual([])
-  })
-})
+  it("should return empty array for empty input", () => {
+    expect(chunk([], 2)).toEqual([]);
+  });
+});
 
-describe('toISOString', () => {
-  it('should convert date to ISO string', () => {
-    const date = new Date('2024-01-15T10:30:00Z')
-    expect(toISOString(date)).toBe('2024-01-15T10:30:00.000Z')
-  })
+describe("toISOString", () => {
+  it("should convert date to ISO string", () => {
+    const date = new Date("2024-01-15T10:30:00Z");
+    expect(toISOString(date)).toBe("2024-01-15T10:30:00.000Z");
+  });
 
-  it('should use current date if no argument', () => {
-    const result = toISOString()
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
-  })
-})
+  it("should use current date if no argument", () => {
+    const result = toISOString();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
+  });
+});
 
-describe('snakeToCamel', () => {
-  it('should convert snake_case to camelCase', () => {
-    expect(snakeToCamel('hello_world')).toBe('helloWorld')
-    expect(snakeToCamel('user_profile_image')).toBe('userProfileImage')
-    expect(snakeToCamel('id')).toBe('id')
-  })
-})
+describe("snakeToCamel", () => {
+  it("should convert snake_case to camelCase", () => {
+    expect(snakeToCamel("hello_world")).toBe("helloWorld");
+    expect(snakeToCamel("user_profile_image")).toBe("userProfileImage");
+    expect(snakeToCamel("id")).toBe("id");
+  });
+});
 
-describe('camelToSnake', () => {
-  it('should convert camelCase to snake_case', () => {
-    expect(camelToSnake('helloWorld')).toBe('hello_world')
-    expect(camelToSnake('userProfileImage')).toBe('user_profile_image')
-    expect(camelToSnake('id')).toBe('id')
-  })
-})
+describe("camelToSnake", () => {
+  it("should convert camelCase to snake_case", () => {
+    expect(camelToSnake("helloWorld")).toBe("hello_world");
+    expect(camelToSnake("userProfileImage")).toBe("user_profile_image");
+    expect(camelToSnake("id")).toBe("id");
+  });
+});
 
-describe('keysToCamel', () => {
-  it('should convert object keys to camelCase', () => {
-    const obj = { user_name: 'test', created_at: '2024-01-01' }
-    expect(keysToCamel(obj)).toEqual({ userName: 'test', createdAt: '2024-01-01' })
-  })
-})
+describe("keysToCamel", () => {
+  it("should convert object keys to camelCase", () => {
+    const obj = { user_name: "test", created_at: "2024-01-01" };
+    expect(keysToCamel(obj)).toEqual({ userName: "test", createdAt: "2024-01-01" });
+  });
+});
 
-describe('keysToSnake', () => {
-  it('should convert object keys to snake_case', () => {
-    const obj = { userName: 'test', createdAt: '2024-01-01' }
-    expect(keysToSnake(obj)).toEqual({ user_name: 'test', created_at: '2024-01-01' })
-  })
-})
+describe("keysToSnake", () => {
+  it("should convert object keys to snake_case", () => {
+    const obj = { userName: "test", createdAt: "2024-01-01" };
+    expect(keysToSnake(obj)).toEqual({ user_name: "test", created_at: "2024-01-01" });
+  });
+});
 
-describe('truncate', () => {
-  it('should truncate string longer than maxLength', () => {
-    expect(truncate('Hello World', 8)).toBe('Hello...')
-  })
+describe("truncate", () => {
+  it("should truncate string longer than maxLength", () => {
+    expect(truncate("Hello World", 8)).toBe("Hello...");
+  });
 
-  it('should not truncate string shorter than or equal to maxLength', () => {
-    expect(truncate('Hello', 10)).toBe('Hello')
-    expect(truncate('Hello', 5)).toBe('Hello')
-  })
-})
+  it("should not truncate string shorter than or equal to maxLength", () => {
+    expect(truncate("Hello", 10)).toBe("Hello");
+    expect(truncate("Hello", 5)).toBe("Hello");
+  });
+});

--- a/app/server/lib/utils.ts
+++ b/app/server/lib/utils.ts
@@ -9,24 +9,18 @@ export function sleep(ms: number): Promise<void> {
  * ランダムな文字列を生成
  */
 export function generateRandomString(length: number = 32): string {
-  const chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   const randomValues = new Uint8Array(length);
   crypto.getRandomValues(randomValues);
-  return Array.from(
-    randomValues,
-    (value) => chars[value % chars.length]
-  ).join("");
+  return Array.from(randomValues, (value) => chars[value % chars.length]).join("");
 }
 
 /**
  * オブジェクトからundefinedのプロパティを削除
  */
-export function removeUndefined<T extends Record<string, unknown>>(
-  obj: T
-): Partial<T> {
+export function removeUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
   return Object.fromEntries(
-    Object.entries(obj).filter(([, value]) => value !== undefined)
+    Object.entries(obj).filter(([, value]) => value !== undefined),
   ) as Partial<T>;
 }
 
@@ -36,7 +30,7 @@ export function removeUndefined<T extends Record<string, unknown>>(
 export function chunk<T>(array: T[], size: number): T[][] {
   const chunkCount = Math.ceil(array.length / size);
   return Array.from({ length: chunkCount }, (_, index) =>
-    array.slice(index * size, index * size + size)
+    array.slice(index * size, index * size + size),
   );
 }
 
@@ -64,23 +58,15 @@ export function camelToSnake(str: string): string {
 /**
  * オブジェクトのキーをキャメルケースに変換
  */
-export function keysToCamel<T extends Record<string, unknown>>(
-  obj: T
-): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(obj).map(([key, value]) => [snakeToCamel(key), value])
-  );
+export function keysToCamel<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(obj).map(([key, value]) => [snakeToCamel(key), value]));
 }
 
 /**
  * オブジェクトのキーをスネークケースに変換
  */
-export function keysToSnake<T extends Record<string, unknown>>(
-  obj: T
-): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(obj).map(([key, value]) => [camelToSnake(key), value])
-  );
+export function keysToSnake<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(obj).map(([key, value]) => [camelToSnake(key), value]));
 }
 
 /**
@@ -95,7 +81,7 @@ export function truncate(str: string, maxLength: number): string {
  */
 export function debounce<T extends (...args: unknown[]) => unknown>(
   func: T,
-  wait: number
+  wait: number,
 ): (...args: Parameters<T>) => void {
   let timeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -114,7 +100,7 @@ export function debounce<T extends (...args: unknown[]) => unknown>(
 export async function retry<T>(
   fn: () => Promise<T>,
   maxRetries: number = 3,
-  delay: number = 1000
+  delay: number = 1000,
 ): Promise<T> {
   let lastError: Error | undefined;
 
@@ -131,4 +117,3 @@ export async function retry<T>(
 
   throw lastError;
 }
-

--- a/app/server/lib/validation.test.ts
+++ b/app/server/lib/validation.test.ts
@@ -1,65 +1,65 @@
-import { describe, it, expect } from 'vitest'
-import { isValidUUID, isValidISBN, isValidEmail, isValidUrl } from './validation'
+import { describe, it, expect } from "vitest";
+import { isValidUUID, isValidISBN, isValidEmail, isValidUrl } from "./validation";
 
-describe('isValidUUID', () => {
-  it('should return true for valid UUID v4', () => {
-    expect(isValidUUID('550e8400-e29b-41d4-a716-446655440000')).toBe(true)
-    expect(isValidUUID('6ba7b810-9dad-11d1-80b4-00c04fd430c8')).toBe(true)
-  })
+describe("isValidUUID", () => {
+  it("should return true for valid UUID v4", () => {
+    expect(isValidUUID("550e8400-e29b-41d4-a716-446655440000")).toBe(true);
+    expect(isValidUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")).toBe(true);
+  });
 
-  it('should return false for invalid UUID', () => {
-    expect(isValidUUID('not-a-uuid')).toBe(false)
-    expect(isValidUUID('550e8400-e29b-41d4-a716')).toBe(false)
-    expect(isValidUUID('')).toBe(false)
-    expect(isValidUUID('550e8400e29b41d4a716446655440000')).toBe(false)
-  })
-})
+  it("should return false for invalid UUID", () => {
+    expect(isValidUUID("not-a-uuid")).toBe(false);
+    expect(isValidUUID("550e8400-e29b-41d4-a716")).toBe(false);
+    expect(isValidUUID("")).toBe(false);
+    expect(isValidUUID("550e8400e29b41d4a716446655440000")).toBe(false);
+  });
+});
 
-describe('isValidISBN', () => {
-  it('should return true for valid ISBN-10', () => {
-    expect(isValidISBN('0123456789')).toBe(true)
-    expect(isValidISBN('012345678X')).toBe(true)
-  })
+describe("isValidISBN", () => {
+  it("should return true for valid ISBN-10", () => {
+    expect(isValidISBN("0123456789")).toBe(true);
+    expect(isValidISBN("012345678X")).toBe(true);
+  });
 
-  it('should return true for valid ISBN-13', () => {
-    expect(isValidISBN('9780123456789')).toBe(true)
-    expect(isValidISBN('9784873119038')).toBe(true)
-  })
+  it("should return true for valid ISBN-13", () => {
+    expect(isValidISBN("9780123456789")).toBe(true);
+    expect(isValidISBN("9784873119038")).toBe(true);
+  });
 
-  it('should return false for invalid ISBN', () => {
-    expect(isValidISBN('123')).toBe(false)
-    expect(isValidISBN('not-an-isbn')).toBe(false)
-    expect(isValidISBN('')).toBe(false)
-    expect(isValidISBN('978012345678')).toBe(false)
-  })
-})
+  it("should return false for invalid ISBN", () => {
+    expect(isValidISBN("123")).toBe(false);
+    expect(isValidISBN("not-an-isbn")).toBe(false);
+    expect(isValidISBN("")).toBe(false);
+    expect(isValidISBN("978012345678")).toBe(false);
+  });
+});
 
-describe('isValidEmail', () => {
-  it('should return true for valid email addresses', () => {
-    expect(isValidEmail('test@example.com')).toBe(true)
-    expect(isValidEmail('user.name@domain.co.jp')).toBe(true)
-    expect(isValidEmail('user+tag@example.org')).toBe(true)
-  })
+describe("isValidEmail", () => {
+  it("should return true for valid email addresses", () => {
+    expect(isValidEmail("test@example.com")).toBe(true);
+    expect(isValidEmail("user.name@domain.co.jp")).toBe(true);
+    expect(isValidEmail("user+tag@example.org")).toBe(true);
+  });
 
-  it('should return false for invalid email addresses', () => {
-    expect(isValidEmail('not-an-email')).toBe(false)
-    expect(isValidEmail('@example.com')).toBe(false)
-    expect(isValidEmail('user@')).toBe(false)
-    expect(isValidEmail('')).toBe(false)
-    expect(isValidEmail('user name@example.com')).toBe(false)
-  })
-})
+  it("should return false for invalid email addresses", () => {
+    expect(isValidEmail("not-an-email")).toBe(false);
+    expect(isValidEmail("@example.com")).toBe(false);
+    expect(isValidEmail("user@")).toBe(false);
+    expect(isValidEmail("")).toBe(false);
+    expect(isValidEmail("user name@example.com")).toBe(false);
+  });
+});
 
-describe('isValidUrl', () => {
-  it('should return true for valid URLs', () => {
-    expect(isValidUrl('https://example.com')).toBe(true)
-    expect(isValidUrl('http://localhost:3000')).toBe(true)
-    expect(isValidUrl('https://example.com/path?query=1')).toBe(true)
-  })
+describe("isValidUrl", () => {
+  it("should return true for valid URLs", () => {
+    expect(isValidUrl("https://example.com")).toBe(true);
+    expect(isValidUrl("http://localhost:3000")).toBe(true);
+    expect(isValidUrl("https://example.com/path?query=1")).toBe(true);
+  });
 
-  it('should return false for invalid URLs', () => {
-    expect(isValidUrl('not-a-url')).toBe(false)
-    expect(isValidUrl('')).toBe(false)
-    expect(isValidUrl('example.com')).toBe(false)
-  })
-})
+  it("should return false for invalid URLs", () => {
+    expect(isValidUrl("not-a-url")).toBe(false);
+    expect(isValidUrl("")).toBe(false);
+    expect(isValidUrl("example.com")).toBe(false);
+  });
+});

--- a/app/server/lib/validation.ts
+++ b/app/server/lib/validation.ts
@@ -20,7 +20,7 @@ export function validate<T>(schema: Type<T>, data: unknown): T {
  */
 export function validateSafe<T>(
   schema: Type<T>,
-  data: unknown
+  data: unknown,
 ): { success: true; data: T } | { success: false; error: string } {
   const result = schema(data);
 
@@ -38,8 +38,7 @@ export function validateSafe<T>(
  * UUIDが有効かどうか
  */
 export function isValidUUID(uuid: string): boolean {
-  const uuidRegex =
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   return uuidRegex.test(uuid);
 }
 

--- a/app/server/lib/validator.test.ts
+++ b/app/server/lib/validator.test.ts
@@ -1,46 +1,38 @@
-import { describe, it, expect } from 'vitest'
-import { Hono } from 'hono'
-import { type } from 'arktype'
-import { env } from 'cloudflare:test'
-import { validator, getValidated } from './validator'
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { type } from "arktype";
+import { env } from "cloudflare:test";
+import { validator, getValidated } from "./validator";
 
-describe('validator middleware', () => {
-  it('should parse numeric query values', async () => {
-    const app = new Hono()
-    const schema = type({ limit: 'number', offset: 'number' })
-    app.get(
-      '/query',
-      validator('query', schema),
-      (c) => c.json(getValidated(c, 'query'))
-    )
+describe("validator middleware", () => {
+  it("should parse numeric query values", async () => {
+    const app = new Hono();
+    const schema = type({ limit: "number", offset: "number" });
+    app.get("/query", validator("query", schema), (c) => c.json(getValidated(c, "query")));
 
-    const res = await app.request('/query?limit=10&offset=5', {}, env)
-    expect(res.status).toBe(200)
-    const body = await res.json() as { limit: number; offset: number }
-    expect(body.limit).toBe(10)
-    expect(body.offset).toBe(5)
-  })
+    const res = await app.request("/query?limit=10&offset=5", {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { limit: number; offset: number };
+    expect(body.limit).toBe(10);
+    expect(body.offset).toBe(5);
+  });
 
-  it('should validate json body', async () => {
-    const app = new Hono()
-    const schema = type({ title: 'string' })
-    app.post(
-      '/json',
-      validator('json', schema),
-      (c) => c.json(getValidated(c, 'json'))
-    )
+  it("should validate json body", async () => {
+    const app = new Hono();
+    const schema = type({ title: "string" });
+    app.post("/json", validator("json", schema), (c) => c.json(getValidated(c, "json")));
 
     const res = await app.request(
-      '/json',
+      "/json",
       {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: 'Test' }),
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "Test" }),
       },
-      env
-    )
-    expect(res.status).toBe(200)
-    const body = await res.json() as { title: string }
-    expect(body.title).toBe('Test')
-  })
-})
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { title: string };
+    expect(body.title).toBe("Test");
+  });
+});

--- a/app/server/lib/validator.ts
+++ b/app/server/lib/validator.ts
@@ -1,18 +1,14 @@
 import type { Context, MiddlewareHandler } from "hono";
 import type { Type } from "arktype";
 
-type ValidatedDataKey =
-  | "validated_json"
-  | "validated_query"
-  | "validated_param"
-  | "validated_form";
+type ValidatedDataKey = "validated_json" | "validated_query" | "validated_param" | "validated_form";
 
 /*
  * Hono用のバリデーターミドルウェア
  */
 export function validator<T>(
   target: "json" | "query" | "param" | "form",
-  schema: Type<T>
+  schema: Type<T>,
 ): MiddlewareHandler {
   return async (c: Context, next) => {
     let data: unknown;
@@ -27,8 +23,11 @@ export function validator<T>(
           Object.entries(c.req.query()).map(([key, value]) => {
             if (!numericKeys.has(key) || value == null) return [key, value];
             const num = Number(value);
-            return [key, !isNaN(num) && isFinite(num) && String(num) === String(value).trim() ? num : value];
-          })
+            return [
+              key,
+              !isNaN(num) && isFinite(num) && String(num) === String(value).trim() ? num : value,
+            ];
+          }),
         );
         break;
       case "param":
@@ -53,7 +52,7 @@ export function validator<T>(
             details: result.message,
           },
         },
-        400
+        400,
       );
     }
 
@@ -68,10 +67,7 @@ export function validator<T>(
 /**
  * 検証済みデータを取得するヘルパー
  */
-export function getValidated<T>(
-  c: Context,
-  target: "json" | "query" | "param" | "form"
-): T {
+export function getValidated<T>(c: Context, target: "json" | "query" | "param" | "form"): T {
   const key = `validated_${target}` as ValidatedDataKey;
   return c.get(key) as T;
 }

--- a/app/server/services/index.ts
+++ b/app/server/services/index.ts
@@ -1,4 +1,2 @@
 export * as oauthService from "./oauth";
 export * as rakutenService from "./rakuten";
-
-

--- a/app/server/services/oauth.test.ts
+++ b/app/server/services/oauth.test.ts
@@ -1,98 +1,101 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
-import type { Env } from '../../types/env'
-import { ExternalApiError } from '../lib/errors'
-import { getAuthUrl, getAccessToken, getUser } from './oauth'
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Env } from "../../types/env";
+import { ExternalApiError } from "../lib/errors";
+import { getAuthUrl, getAccessToken, getUser } from "./oauth";
 
 const testEnv = {
-  APP_URL: 'https://example.com',
-  GITHUB_CLIENT_ID: 'github-id',
-  GITHUB_CLIENT_SECRET: 'github-secret',
-  GOOGLE_CLIENT_ID: 'google-id',
-  GOOGLE_CLIENT_SECRET: 'google-secret',
-} as Env
+  APP_URL: "https://example.com",
+  GITHUB_CLIENT_ID: "github-id",
+  GITHUB_CLIENT_SECRET: "github-secret",
+  GOOGLE_CLIENT_ID: "google-id",
+  GOOGLE_CLIENT_SECRET: "google-secret",
+} as Env;
 
-describe('oauth service', () => {
+describe("oauth service", () => {
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('should build github auth url', () => {
-    const url = getAuthUrl('github', 'state123', testEnv)
-    const parsed = new URL(url)
-    expect(parsed.host).toBe('github.com')
-    expect(parsed.searchParams.get('client_id')).toBe('github-id')
-    expect(parsed.searchParams.get('state')).toBe('state123')
-    expect(parsed.searchParams.get('redirect_uri')).toBe(
-      'https://example.com/api/auth/github/callback'
-    )
-  })
+  it("should build github auth url", () => {
+    const url = getAuthUrl("github", "state123", testEnv);
+    const parsed = new URL(url);
+    expect(parsed.host).toBe("github.com");
+    expect(parsed.searchParams.get("client_id")).toBe("github-id");
+    expect(parsed.searchParams.get("state")).toBe("state123");
+    expect(parsed.searchParams.get("redirect_uri")).toBe(
+      "https://example.com/api/auth/github/callback",
+    );
+  });
 
-  it('should build google auth url', () => {
-    const url = getAuthUrl('google', 'state456', testEnv)
-    const parsed = new URL(url)
-    expect(parsed.host).toBe('accounts.google.com')
-    expect(parsed.searchParams.get('client_id')).toBe('google-id')
-    expect(parsed.searchParams.get('state')).toBe('state456')
-    expect(parsed.searchParams.get('redirect_uri')).toBe(
-      'https://example.com/api/auth/google/callback'
-    )
-  })
+  it("should build google auth url", () => {
+    const url = getAuthUrl("google", "state456", testEnv);
+    const parsed = new URL(url);
+    expect(parsed.host).toBe("accounts.google.com");
+    expect(parsed.searchParams.get("client_id")).toBe("google-id");
+    expect(parsed.searchParams.get("state")).toBe("state456");
+    expect(parsed.searchParams.get("redirect_uri")).toBe(
+      "https://example.com/api/auth/google/callback",
+    );
+  });
 
-  it('should return github access token', async () => {
+  it("should return github access token", async () => {
     vi.stubGlobal(
-      'fetch',
-      vi.fn(async () =>
-        new Response(JSON.stringify({ access_token: 'token-123' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      )
-    )
-
-    const token = await getAccessToken('github', 'code', testEnv)
-    expect(token).toBe('token-123')
-  })
-
-  it('should throw when github token response is invalid', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () =>
-        new Response(JSON.stringify({ error: 'bad' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      )
-    )
-
-    await expect(getAccessToken('github', 'code', testEnv)).rejects.toBeInstanceOf(
-      ExternalApiError
-    )
-  })
-
-  it('should return github user when email is present', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () =>
-        new Response(
-          JSON.stringify({
-            id: 1,
-            login: 'octo',
-            name: 'Octo',
-            email: 'octo@example.com',
-            avatar_url: 'https://example.com/a.png',
-            bio: null,
-          }),
-          {
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ access_token: "token-123" }), {
             status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          }
-        )
-      )
-    )
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
 
-    const user = await getUser('github', 'token')
-    expect(user.email).toBe('octo@example.com')
-    expect(user.provider).toBe('github')
-    expect(user.username).toBe('octo')
-  })
-})
+    const token = await getAccessToken("github", "code", testEnv);
+    expect(token).toBe("token-123");
+  });
+
+  it("should throw when github token response is invalid", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ error: "bad" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+
+    await expect(getAccessToken("github", "code", testEnv)).rejects.toBeInstanceOf(
+      ExternalApiError,
+    );
+  });
+
+  it("should return github user when email is present", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              id: 1,
+              login: "octo",
+              name: "Octo",
+              email: "octo@example.com",
+              avatar_url: "https://example.com/a.png",
+              bio: null,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+      ),
+    );
+
+    const user = await getUser("github", "token");
+    expect(user.email).toBe("octo@example.com");
+    expect(user.provider).toBe("github");
+    expect(user.username).toBe("octo");
+  });
+});

--- a/app/server/services/oauth.ts
+++ b/app/server/services/oauth.ts
@@ -14,11 +14,7 @@ export interface OAuthUser {
 /**
  * OAuth認証URLを生成
  */
-export function getAuthUrl(
-  provider: "github" | "google",
-  state: string,
-  env: Env
-): string {
+export function getAuthUrl(provider: "github" | "google", state: string, env: Env): string {
   const redirectUri = `${env.APP_URL}/api/auth/${provider}/callback`;
 
   if (provider === "github") {
@@ -52,39 +48,33 @@ export function getAuthUrl(
 export async function getAccessToken(
   provider: "github" | "google",
   code: string,
-  env: Env
+  env: Env,
 ): Promise<string> {
   const redirectUri = `${env.APP_URL}/api/auth/${provider}/callback`;
 
   if (provider === "github") {
-    const response = await fetch(
-      "https://github.com/login/oauth/access_token",
-      {
-        method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          client_id: env.GITHUB_CLIENT_ID,
-          client_secret: env.GITHUB_CLIENT_SECRET,
-          code,
-          redirect_uri: redirectUri,
-        }),
-      }
-    );
+    const response = await fetch("https://github.com/login/oauth/access_token", {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        client_id: env.GITHUB_CLIENT_ID,
+        client_secret: env.GITHUB_CLIENT_SECRET,
+        code,
+        redirect_uri: redirectUri,
+      }),
+    });
 
     if (!response.ok) {
       throw new ExternalApiError("Failed to get GitHub access token", "GitHub");
     }
 
-    const data = await response.json() as { access_token?: string; error?: string };
+    const data = (await response.json()) as { access_token?: string; error?: string };
 
     if (data.error || !data.access_token) {
-      throw new ExternalApiError(
-        data.error || "No access token received",
-        "GitHub"
-      );
+      throw new ExternalApiError(data.error || "No access token received", "GitHub");
     }
 
     return data.access_token;
@@ -109,13 +99,10 @@ export async function getAccessToken(
       throw new ExternalApiError("Failed to get Google access token", "Google");
     }
 
-    const data = await response.json() as { access_token?: string; error?: string };
+    const data = (await response.json()) as { access_token?: string; error?: string };
 
     if (data.error || !data.access_token) {
-      throw new ExternalApiError(
-        data.error || "No access token received",
-        "Google"
-      );
+      throw new ExternalApiError(data.error || "No access token received", "Google");
     }
 
     return data.access_token;
@@ -129,7 +116,7 @@ export async function getAccessToken(
  */
 export async function getUser(
   provider: "github" | "google",
-  accessToken: string
+  accessToken: string,
 ): Promise<OAuthUser> {
   if (provider === "github") {
     return getGitHubUser(accessToken);
@@ -158,7 +145,7 @@ async function getGitHubUser(accessToken: string): Promise<OAuthUser> {
     throw new ExternalApiError("Failed to fetch GitHub user", "GitHub");
   }
 
-  const data = await response.json() as {
+  const data = (await response.json()) as {
     id: number;
     login: string;
     name: string | null;
@@ -179,7 +166,7 @@ async function getGitHubUser(accessToken: string): Promise<OAuthUser> {
     });
 
     if (emailResponse.ok) {
-      const emails = await emailResponse.json() as Array<{
+      const emails = (await emailResponse.json()) as Array<{
         email: string;
         primary: boolean;
         verified: boolean;
@@ -208,20 +195,17 @@ async function getGitHubUser(accessToken: string): Promise<OAuthUser> {
  * Google ユーザー情報取得
  */
 async function getGoogleUser(accessToken: string): Promise<OAuthUser> {
-  const response = await fetch(
-    "https://www.googleapis.com/oauth2/v2/userinfo",
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }
-  );
+  const response = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
 
   if (!response.ok) {
     throw new ExternalApiError("Failed to fetch Google user", "Google");
   }
 
-  const data = await response.json() as {
+  const data = (await response.json()) as {
     id: string;
     email: string;
     name: string;
@@ -238,5 +222,3 @@ async function getGoogleUser(accessToken: string): Promise<OAuthUser> {
     bio: null,
   };
 }
-
-

--- a/app/server/services/rakuten.test.ts
+++ b/app/server/services/rakuten.test.ts
@@ -1,104 +1,106 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
-import { searchBooks, searchByISBN, searchByAuthor, sortByPublishedDateDesc } from './rakuten'
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { searchBooks, searchByISBN, searchByAuthor, sortByPublishedDateDesc } from "./rakuten";
 
-describe('rakuten service', () => {
+describe("rakuten service", () => {
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('should map search results and cap hits', async () => {
-    let requestedUrl = ''
+  it("should map search results and cap hits", async () => {
+    let requestedUrl = "";
     vi.stubGlobal(
-      'fetch',
+      "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
-        requestedUrl = input.toString()
+        requestedUrl = input.toString();
         return new Response(
           JSON.stringify({
             Items: [
               {
                 Item: {
-                  isbn: '9780000000001',
-                  title: 'Test Book',
-                  author: 'Author A/Author B',
-                  publisherName: 'Publisher',
-                  salesDate: '2024年1月1日',
-                  size: '320p',
-                  itemCaption: 'Desc',
-                  largeImageUrl: 'https://example.com/cover.png',
-                  affiliateUrl: 'https://example.com/aff',
+                  isbn: "9780000000001",
+                  title: "Test Book",
+                  author: "Author A/Author B",
+                  publisherName: "Publisher",
+                  salesDate: "2024年1月1日",
+                  size: "320p",
+                  itemCaption: "Desc",
+                  largeImageUrl: "https://example.com/cover.png",
+                  affiliateUrl: "https://example.com/aff",
                 },
               },
             ],
             pageCount: 1,
             hits: 1,
           }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      })
-    )
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
 
-    const result = await searchBooks('query', 'app-id', 20, 1)
-    const url = new URL(requestedUrl)
-    expect(url.searchParams.get('hits')).toBe('10')
-    expect(result.results[0].authors).toEqual(['Author A', 'Author B'])
-    expect(result.results[0].pageCount).toBe(320)
-    expect(result.hits).toBe(1)
-  })
+    const result = await searchBooks("query", "app-id", 20, 1);
+    const url = new URL(requestedUrl);
+    expect(url.searchParams.get("hits")).toBe("10");
+    expect(result.results[0].authors).toEqual(["Author A", "Author B"]);
+    expect(result.results[0].pageCount).toBe(320);
+    expect(result.hits).toBe(1);
+  });
 
-  it('should return null for ISBN search with no results', async () => {
+  it("should return null for ISBN search with no results", async () => {
     vi.stubGlobal(
-      'fetch',
-      vi.fn(async () =>
-        new Response(JSON.stringify({ Items: [], pageCount: 0, hits: 0 }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      )
-    )
-
-    const result = await searchByISBN('9780000000001', 'app-id')
-    expect(result).toBeNull()
-  })
-
-  it('should return author search results', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () =>
-        new Response(
-          JSON.stringify({
-            Items: [
-              {
-                Item: {
-                  isbn: '9780000000002',
-                  title: 'Author Book',
-                  author: 'Author C',
-                  publisherName: 'Publisher',
-                  salesDate: '2023年12月1日',
-                  size: '200p',
-                  itemCaption: '',
-                  largeImageUrl: '',
-                  affiliateUrl: '',
-                },
-              },
-            ],
-            pageCount: 1,
-            hits: 1,
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ Items: [], pageCount: 0, hits: 0 }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
           }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      )
-    )
+      ),
+    );
 
-    const result = await searchByAuthor('Author', 'app-id', 5)
-    expect(result).toHaveLength(1)
-    expect(result[0].title).toBe('Author Book')
-  })
+    const result = await searchByISBN("9780000000001", "app-id");
+    expect(result).toBeNull();
+  });
 
-  it('should sort by published date desc', () => {
+  it("should return author search results", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              Items: [
+                {
+                  Item: {
+                    isbn: "9780000000002",
+                    title: "Author Book",
+                    author: "Author C",
+                    publisherName: "Publisher",
+                    salesDate: "2023年12月1日",
+                    size: "200p",
+                    itemCaption: "",
+                    largeImageUrl: "",
+                    affiliateUrl: "",
+                  },
+                },
+              ],
+              pageCount: 1,
+              hits: 1,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+
+    const result = await searchByAuthor("Author", "app-id", 5);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("Author Book");
+  });
+
+  it("should sort by published date desc", () => {
     const sorted = sortByPublishedDateDesc([
-      { title: 'Old', publishedDate: '2020年1月1日' } as never,
-      { title: 'New', publishedDate: '2024年1月1日' } as never,
-    ])
-    expect(sorted[0].title).toBe('New')
-  })
-})
+      { title: "Old", publishedDate: "2020年1月1日" } as never,
+      { title: "New", publishedDate: "2024年1月1日" } as never,
+    ]);
+    expect(sorted[0].title).toBe("New");
+  });
+});

--- a/app/server/services/rakuten.ts
+++ b/app/server/services/rakuten.ts
@@ -40,8 +40,9 @@ export async function searchBooks(
   query: string,
   applicationId: string,
   limit: number = 20,
-  page: number = 1
-): Promise<{ results: BookSearchResult[]; hits: number; pageCount: number}> { // 戻り値を変更
+  page: number = 1,
+): Promise<{ results: BookSearchResult[]; hits: number; pageCount: number }> {
+  // 戻り値を変更
   const url = new URL(RAKUTEN_API_BASE);
   url.searchParams.set("applicationId", applicationId);
   url.searchParams.set("title", query);
@@ -53,10 +54,7 @@ export async function searchBooks(
     const response = await fetch(url.toString());
 
     if (!response.ok) {
-      throw new ExternalApiError(
-        `Rakuten API returned ${response.status}`,
-        "Rakuten"
-      );
+      throw new ExternalApiError(`Rakuten API returned ${response.status}`, "Rakuten");
     }
 
     const data: RakutenBookResponse = await response.json();
@@ -65,7 +63,7 @@ export async function searchBooks(
       results: data.Items.map((item) => mapRakutenItem(item.Item)),
       hits: data.hits,
       pageCount: data.pageCount,
-    } 
+    };
   } catch (error) {
     if (error instanceof ExternalApiError) throw error;
     throw new ExternalApiError("Failed to fetch from Rakuten API", "Rakuten", error);
@@ -77,7 +75,7 @@ export async function searchBooks(
  */
 export async function searchByISBN(
   isbn: string,
-  applicationId: string
+  applicationId: string,
 ): Promise<BookSearchResult | null> {
   const url = new URL(RAKUTEN_API_BASE);
   url.searchParams.set("applicationId", applicationId);
@@ -88,10 +86,7 @@ export async function searchByISBN(
     const response = await fetch(url.toString());
 
     if (!response.ok) {
-      throw new ExternalApiError(
-        `Rakuten API returned ${response.status}`,
-        "Rakuten"
-      );
+      throw new ExternalApiError(`Rakuten API returned ${response.status}`, "Rakuten");
     }
 
     const data: RakutenBookResponse = await response.json();
@@ -113,7 +108,7 @@ export async function searchByISBN(
 export async function searchByAuthor(
   author: string,
   applicationId: string,
-  limit: number = 20
+  limit: number = 20,
 ): Promise<BookSearchResult[]> {
   const url = new URL(RAKUTEN_API_BASE);
   url.searchParams.set("applicationId", applicationId);
@@ -125,10 +120,7 @@ export async function searchByAuthor(
     const response = await fetch(url.toString());
 
     if (!response.ok) {
-      throw new ExternalApiError(
-        `Rakuten API returned ${response.status}`,
-        "Rakuten"
-      );
+      throw new ExternalApiError(`Rakuten API returned ${response.status}`, "Rakuten");
     }
 
     const data: RakutenBookResponse = await response.json();
@@ -166,7 +158,7 @@ function parseAuthors(authorString: string): string[] {
   if (!authorString) return [];
 
   // 複数の区切り文字に対応
-  const separators = /[\/、,，]/;
+  const separators = /[/、,，]/;
   return authorString
     .split(separators)
     .map((author) => author.trim())
@@ -196,19 +188,13 @@ function parsePublishedDate(publishedDate: string): Date | null {
 
   const [, year, month, day] = match;
 
-  return new Date(
-    Number(year),
-    Number(month) - 1,
-    Number(day)
-  );
+  return new Date(Number(year), Number(month) - 1, Number(day));
 }
 
 /**
  * 本の配列を、出版日が新しい順に並び替え
  */
-export function sortByPublishedDateDesc(
-  books: BookSearchResult[]
-): BookSearchResult[] {
+export function sortByPublishedDateDesc(books: BookSearchResult[]): BookSearchResult[] {
   return [...books].sort((before, after) => {
     const beforeDate = parsePublishedDate(before.publishedDate);
     const afterDate = parsePublishedDate(after.publishedDate);
@@ -220,5 +206,3 @@ export function sortByPublishedDateDesc(
     return afterDate.getTime() - beforeDate.getTime();
   });
 }
-
-

--- a/app/style.css
+++ b/app/style.css
@@ -1,8 +1,12 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 
 @keyframes slide-in {
-  from { transform: translateX(-100%); }
-  to { transform: translateX(0); }
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
 }
 
 .animate-slide-in {
@@ -11,13 +15,19 @@
 
 @media (max-width: 767px) {
   #main-layout header {
-    transition: height 0.3s, opacity 0.3s, overflow 0s 0.3s;
+    transition:
+      height 0.3s,
+      opacity 0.3s,
+      overflow 0s 0.3s;
   }
   #main-layout[data-scrolled="down"] header {
     height: 0;
     opacity: 0;
     overflow: hidden;
     pointer-events: none;
-    transition: height 0.3s, opacity 0.3s, overflow 0s;
+    transition:
+      height 0.3s,
+      opacity 0.3s,
+      overflow 0s;
   }
 }

--- a/app/test/env.d.ts
+++ b/app/test/env.d.ts
@@ -3,9 +3,9 @@ import type { Env } from "../types/env";
 type D1Database = Env["DB"];
 type KVNamespace = Env["KV"];
 
-declare module 'cloudflare:test' {
+declare module "cloudflare:test" {
   interface ProvidedEnv {
-    DB: D1Database
-    KV: KVNamespace
+    DB: D1Database;
+    KV: KVNamespace;
   }
 }

--- a/app/test/helpers.ts
+++ b/app/test/helpers.ts
@@ -9,33 +9,33 @@ type KVNamespace = Env["KV"];
 export async function createTestUser(
   db: D1Database,
   overrides: Partial<{
-    id: string
-    username: string
-    email: string
-    name: string
-    provider: string
-    providerId: string
-  }> = {}
+    id: string;
+    username: string;
+    email: string;
+    name: string;
+    provider: string;
+    providerId: string;
+  }> = {},
 ) {
-  const now = new Date().toISOString()
-  const userId = overrides.id || crypto.randomUUID()
+  const now = new Date().toISOString();
+  const userId = overrides.id || crypto.randomUUID();
   const user = {
     id: userId,
     username: overrides.username || `test_user_${userId.slice(0, 8)}`,
     email: overrides.email || `test_${userId.slice(0, 8)}@example.com`,
-    name: overrides.name || 'Test User',
+    name: overrides.name || "Test User",
     bio: null,
     avatar_url: null,
-    provider: overrides.provider || 'github',
+    provider: overrides.provider || "github",
     provider_id: overrides.providerId || `provider_${userId.slice(0, 8)}`,
     created_at: now,
     updated_at: now,
-  }
+  };
 
   await db
     .prepare(
       `INSERT INTO users (id, username, email, name, bio, avatar_url, provider, provider_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .bind(
       user.id,
@@ -47,23 +47,20 @@ export async function createTestUser(
       user.provider,
       user.provider_id,
       user.created_at,
-      user.updated_at
+      user.updated_at,
     )
-    .run()
+    .run();
 
-  return user
+  return user;
 }
 
 /**
  * テスト用のセッションを作成
  */
-export async function createTestSession(
-  kv: KVNamespace,
-  userId: string
-): Promise<string> {
-  const sessionId = crypto.randomUUID()
-  await kv.put(`session:${sessionId}`, userId, { expirationTtl: 3600 })
-  return sessionId
+export async function createTestSession(kv: KVNamespace, userId: string): Promise<string> {
+  const sessionId = crypto.randomUUID();
+  await kv.put(`session:${sessionId}`, userId, { expirationTtl: 3600 });
+  return sessionId;
 }
 
 /**
@@ -73,41 +70,41 @@ export async function createTestBook(
   db: D1Database,
   userId: string,
   overrides: Partial<{
-    id: string
-    title: string
-    authors: string[]
-    status: 'unread' | 'reading' | 'completed'
-    pageCount: number
-    currentPage: number
-  }> = {}
+    id: string;
+    title: string;
+    authors: string[];
+    status: "unread" | "reading" | "completed";
+    pageCount: number;
+    currentPage: number;
+  }> = {},
 ) {
-  const now = new Date().toISOString()
-  const bookId = overrides.id || crypto.randomUUID()
+  const now = new Date().toISOString();
+  const bookId = overrides.id || crypto.randomUUID();
   const book = {
     id: bookId,
     user_id: userId,
     rakuten_books_id: null,
-    title: overrides.title || 'Test Book',
-    authors: JSON.stringify(overrides.authors || ['Test Author']),
-    publisher: 'Test Publisher',
-    published_date: '2024-01-01',
-    isbn: '9784873119038',
+    title: overrides.title || "Test Book",
+    authors: JSON.stringify(overrides.authors || ["Test Author"]),
+    publisher: "Test Publisher",
+    published_date: "2024-01-01",
+    isbn: "9784873119038",
     page_count: overrides.pageCount || 300,
-    description: 'A test book description',
+    description: "A test book description",
     thumbnail_url: null,
     rakuten_affiliate_url: null,
-    status: overrides.status || 'unread',
+    status: overrides.status || "unread",
     current_page: overrides.currentPage || 0,
     memo: null,
     finished_at: null,
     created_at: now,
     updated_at: now,
-  }
+  };
 
   await db
     .prepare(
       `INSERT INTO books (id, user_id, rakuten_books_id, title, authors, publisher, published_date, isbn, page_count, description, thumbnail_url, rakuten_affiliate_url, status, current_page, memo, finished_at, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .bind(
       book.id,
@@ -127,39 +124,35 @@ export async function createTestBook(
       book.memo,
       book.finished_at,
       book.created_at,
-      book.updated_at
+      book.updated_at,
     )
-    .run()
+    .run();
 
-  return book
+  return book;
 }
 
 /**
  * テスト用のタグを作成
  */
-export async function createTestTag(
-  db: D1Database,
-  userId: string,
-  name?: string
-) {
-  const now = new Date().toISOString()
-  const tagId = crypto.randomUUID()
+export async function createTestTag(db: D1Database, userId: string, name?: string) {
+  const now = new Date().toISOString();
+  const tagId = crypto.randomUUID();
   const tag = {
     id: tagId,
     user_id: userId,
     name: name || `tag_${tagId.slice(0, 8)}`,
     created_at: now,
-  }
+  };
 
   await db
     .prepare(
       `INSERT INTO tags (id, user_id, name, created_at)
-       VALUES (?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?)`,
     )
     .bind(tag.id, tag.user_id, tag.name, tag.created_at)
-    .run()
+    .run();
 
-  return tag
+  return tag;
 }
 
 /**
@@ -167,12 +160,12 @@ export async function createTestTag(
  */
 export async function cleanupDatabase(db: D1Database) {
   await db.batch([
-    db.prepare('DELETE FROM book_tags'),
-    db.prepare('DELETE FROM tags'),
-    db.prepare('DELETE FROM books'),
-    db.prepare('DELETE FROM sessions'),
-    db.prepare('DELETE FROM users'),
-  ])
+    db.prepare("DELETE FROM book_tags"),
+    db.prepare("DELETE FROM tags"),
+    db.prepare("DELETE FROM books"),
+    db.prepare("DELETE FROM sessions"),
+    db.prepare("DELETE FROM users"),
+  ]);
 }
 
 /**
@@ -181,13 +174,13 @@ export async function cleanupDatabase(db: D1Database) {
 export function createAuthenticatedRequest(
   url: string,
   sessionId: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
 ): Request {
-  const headers = new Headers(options.headers)
-  headers.set('Cookie', `session_id=${sessionId}`)
+  const headers = new Headers(options.headers);
+  headers.set("Cookie", `session_id=${sessionId}`);
 
   return new Request(url, {
     ...options,
     headers,
-  })
+  });
 }

--- a/app/test/setup.ts
+++ b/app/test/setup.ts
@@ -1,5 +1,5 @@
-import { env } from 'cloudflare:test'
-import { beforeAll } from 'vitest'
+import { env } from "cloudflare:test";
+import { beforeAll } from "vitest";
 
 // テスト前にデータベーススキーマをセットアップ
 beforeAll(async () => {
@@ -17,7 +17,7 @@ beforeAll(async () => {
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     )
-  `).run()
+  `).run();
 
   // books テーブル
   await env.DB.prepare(`
@@ -42,7 +42,7 @@ beforeAll(async () => {
       updated_at TEXT NOT NULL,
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     )
-  `).run()
+  `).run();
 
   // tags テーブル
   await env.DB.prepare(`
@@ -54,7 +54,7 @@ beforeAll(async () => {
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
       UNIQUE(user_id, name)
     )
-  `).run()
+  `).run();
 
   // book_tags テーブル
   await env.DB.prepare(`
@@ -65,7 +65,7 @@ beforeAll(async () => {
       FOREIGN KEY (book_id) REFERENCES books(id) ON DELETE CASCADE,
       FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
     )
-  `).run()
+  `).run();
 
   // sessions テーブル（存在しない場合のみ）
   await env.DB.prepare(`
@@ -75,5 +75,5 @@ beforeAll(async () => {
       created_at TEXT NOT NULL,
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     )
-  `).run()
-})
+  `).run();
+});

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -124,4 +124,3 @@ export interface PublicBook {
   finishedAt: string | null;
   tags: string[];
 }
-

--- a/app/types/database.ts
+++ b/app/types/database.ts
@@ -159,4 +159,3 @@ export interface BookStats {
   completed: number;
   unread: number;
 }
-

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "basic",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -7,6 +8,10 @@
     "preview": "wrangler dev",
     "deploy": "pnpm run build && wrangler deploy",
     "typecheck": "tsc --noEmit",
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix",
+    "format": "oxfmt",
+    "format:check": "oxfmt --check",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -18,7 +23,6 @@
     "db:console:local": "wrangler d1 execute gidoku-db --local --command",
     "db:console:prod": "wrangler d1 execute gidoku-db --remote --command"
   },
-  "private": true,
   "dependencies": {
     "@lordicon/element": "^2.0.1",
     "arktype": "^2.0.0-rc.19",
@@ -33,6 +37,8 @@
     "@hono/vite-dev-server": "^0.18.2",
     "@tailwindcss/vite": "^4.0.9",
     "@types/node": "^24.10.2",
+    "oxfmt": "^0.55.0",
+    "oxlint": "^1.70.0",
     "tailwindcss": "^4.0.9",
     "tsx": "^4.19.2",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,12 @@ importers:
       '@types/node':
         specifier: ^24.10.2
         version: 24.10.2
+      oxfmt:
+        specifier: ^0.55.0
+        version: 0.55.0
+      oxlint:
+        specifier: ^1.70.0
+        version: 1.70.0
       tailwindcss:
         specifier: ^4.0.9
         version: 4.1.17
@@ -835,6 +841,234 @@ packages:
   '@lordicon/web@1.0.0':
     resolution: {integrity: sha512-ffFZGtMpAJiYjFYiWOoPMCZt5Toacu7cvycC9yk8wDhc5WtXxnzhjaxHlZ3qM5PLYJlAF2dYeIUqcJCkH2f+dw==}
 
+  '@oxfmt/binding-android-arm-eabi@0.55.0':
+    resolution: {integrity: sha512-+rFDOqQe5LOWgxrAJaZgLRudr6GQm0wGI6gtu7vVkrdLGjNMUSGbAlaCr8j7F2H2Er97vYQCU8WDb30onqMM1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.55.0':
+    resolution: {integrity: sha512-ctulLq8s3x8Zmvw6+iccB09TIKERAklRSmbJ10gk8mlAn05qZxoyo52dj3Hi9IJcmDSwF54fQaTVh2CbL6PInw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.55.0':
+    resolution: {integrity: sha512-xDQczLH9pw/RBk1h/GH0qcGMm8hQtmtVHBNLSH3lk1gEIR09hZ4L+mJQl4VqiVAvPK9VG9PYrWWuSQLt7xTbiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.55.0':
+    resolution: {integrity: sha512-JaNoFCkF2CJdGgpPSMbuO9HVyXyoNGIhMHPvp6NYAjeVKw9XEYc0HcUWJLPQa3Q69WV5wMa9m5jPMJPtbLtcRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.55.0':
+    resolution: {integrity: sha512-DNbszhpg6S2MIzax5azdHFTTBIVkR5xr8yyRZuA4yoDAwOkzIp3tmldgKZM2+VlT+hJIG0xUksA+elISzMEAfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.55.0':
+    resolution: {integrity: sha512-2snoaoRfFFyGnbOcKUK36rREBYxe/Xgz3uHbiA5zbCB/s6R4DQj4mHqYAaWWhgizCUSDxV8cE9zAZ0XleNpKGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.55.0':
+    resolution: {integrity: sha512-q1aktHF/WRpSK81BX1dE/9vWrS2jGw1Nax2kb4DBLGAewubCLcoNyp4Zl/NSMgbv3vUS46Z33wIQkBVYOP3PYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.55.0':
+    resolution: {integrity: sha512-VD0y36aENezl/3tsclA/4G53Cc7iV+7Uoh7gz4yvcOTaEYBtJpQsE6PKDGTtUtOvGS4kv51ybfXY/nWZejO5IA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-musl@0.55.0':
+    resolution: {integrity: sha512-r8xlKJFcsRmn0H5jZrdORae6RX9jDBrZVvOoxF+bCQtampQJClv80aZEHsv+NsLsp2KCE5ql79O7DpPVzYWpXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.55.0':
+    resolution: {integrity: sha512-GRKv/HXHcwIVld/WU61rF0g0R16hl5EJ+ScKdpjevT57lnLnagj/U2YUbXf2mT+2Pg1uCzWC+mvGicPV3CDdLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.55.0':
+    resolution: {integrity: sha512-rdv57enTiPtpSYRMKfAiEbQb0Puw5t9N7isVinDoo5qeLDScro2gznmZqSgSWbVZRzLisTeCTW8Qwgw0bOHv3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.55.0':
+    resolution: {integrity: sha512-7v1nNrlD43VY6+sYQ6efYyb3lE6QY182304PD/768ZxTjOmFd/3dQa3u/nGBUAXYdGSWOQc5N3PnS0QzUXyEIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.55.0':
+    resolution: {integrity: sha512-f4lJLUSPOgScjFl9LiflKCTocyNRwE25JmTMbN4XQdDjoZzEHjqf3wA3VESF1/csg7i8m7+EQLbrZyYDqe10UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-gnu@0.55.0':
+    resolution: {integrity: sha512-MihqiPziJNoWy4MqNSV+jVA1g+07iQDjZiR0vaCaDoPgFEiJpCMsxamktzLV07cEeQsSJ04vQaU4CzCQwIvtDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-linux-x64-musl@0.55.0':
+    resolution: {integrity: sha512-Yqghym7KYAVjP9MmSrNZiDeerMuoejNjo0r3ox5H3GDKk8eAfl8VyJm9i+pWCLDCTnAbcTUMMN2ZKjUYXH1v3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxfmt/binding-openharmony-arm64@0.55.0':
+    resolution: {integrity: sha512-s5SDvVVSbyQl1V5UU3Yl12M+XLUQ3rl5SglNqgAA2K4PXUtQhyNSS00wivONPEnNo5W01rCou8WkDNyvI/RGHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.55.0':
+    resolution: {integrity: sha512-7p9FB5R32tw2KyyNX3wpQrR2WHwEHvMEiBlGXxeTCaRMCVNx3UtFMAUbaQ/pRNWIrEUZmYhJ6tcUH52uPTRYjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.55.0':
+    resolution: {integrity: sha512-ZYqj3fDnOT1IaVGMP5kpmkQl4F3tQIm2ZyAxvqkJYmI0xgWWak4ss4XYwv3VDfM+TWXeC9K4uQ/wW5jm/5XABA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.55.0':
+    resolution: {integrity: sha512-eEYT5tivGnGbPHuOHuQpi6CGLObhh0re/5jcNQHihD2GRYkTM85dyi5a19zjP8Q00t1uqAx+/QGLUGdHeqzWyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.70.0':
+    resolution: {integrity: sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.70.0':
+    resolution: {integrity: sha512-qI8o4HZjeGiBrWv+pJv4lH0Yi2Gl/JSp/EumBUApezJprIKa5PS4nU0lQsQngtky8k+SplQIOjv6hwu0SSxeyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.70.0':
+    resolution: {integrity: sha512-8KjgVVHI5F9nVwHCRwwA78Ty7zNKP4Wd9OeN5PSv3iu/F/u1RVXoOCgLhWqust6HmwQG6xc8c+RCyaWENy24+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.70.0':
+    resolution: {integrity: sha512-WVydssv5PSUBXFJTdNBWlmGkbNmvPGaFt/2SUT/EZRB6bq6bEOHmMlbnupZD5jmlEvi9+mZJHi8TCw15lyfSfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.70.0':
+    resolution: {integrity: sha512-hJucmUf8OlinHNb1R7fI4Fw6WsAstOz7i8nmkWQfiHoZXtbufNm+MxiDTIMk1ggh2Ro4vLzgQ+bKvRY54MZoRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.70.0':
+    resolution: {integrity: sha512-1BnS7wbCYDSXwWzJJ+mc3NURoha6m6m6RT5c6vgAY3oz7C3OVXP+S0awo2mRq97arrJkVvO3qRQfyAHL+76xtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.70.0':
+    resolution: {integrity: sha512-yKy/UdbR55+M2yEcuiV5DCNC/gdQAjr/GioUy50QwBzSrKm8ueWADqyRLS9Xk+qjNeCYGg6A8FvUBds56ttfqg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.70.0':
+    resolution: {integrity: sha512-0A5XJ4alvmqFUFP/4oYSyaO+qLto/HrKEWTSaegiVl+HOufFngK2BjYw9x4RbwBt/du5QG6l5q1zeWiJYYG5yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-musl@1.70.0':
+    resolution: {integrity: sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.70.0':
+    resolution: {integrity: sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.70.0':
+    resolution: {integrity: sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-musl@1.70.0':
+    resolution: {integrity: sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-s390x-gnu@1.70.0':
+    resolution: {integrity: sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-gnu@1.70.0':
+    resolution: {integrity: sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-musl@1.70.0':
+    resolution: {integrity: sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-openharmony-arm64@1.70.0':
+    resolution: {integrity: sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.70.0':
+    resolution: {integrity: sha512-icAEsUI7JbW1TMRdEXV83mVAInhRVQYuuAlPpxdGwJ95chNdnCzjloRW8GglT0WvzOEZSio6fnYSk2DJ2Hv7LQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.70.0':
+    resolution: {integrity: sha512-FHMSWbVsPVs/f+Jcl04ws4JJ2wUnauyTzlpxWRG/lSO/8GpX08Fo2gQZqdA6CrRFI+zvkxl+N/KwJGWfUwYVZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.70.0':
+    resolution: {integrity: sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@poppinss/colors@4.1.5':
     resolution: {integrity: sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw==}
 
@@ -1530,6 +1764,32 @@ packages:
     resolution: {integrity: sha512-3VW/8JpPqPvnJvseXowjZcirPisssnBuDikk6JIZ8jQzF7KJQX52iPFX4RYYxLycYH7IbMRSPUOga/esVjy5Yg==}
     engines: {node: '>=18'}
 
+  oxfmt@0.55.0:
+    resolution: {integrity: sha512-jSj2wCTakwgPMxkfiVZX0jf+nX+Nz6xlyAZjqNE0qXTFdCBPYlP6JAN+ODjmealw7DXBjOzYbdsqwBMAZnPZ6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
+  oxlint@1.70.0:
+    resolution: {integrity: sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -1637,6 +1897,10 @@ packages:
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -2339,6 +2603,120 @@ snapshots:
 
   '@lordicon/web@1.0.0': {}
 
+  '@oxfmt/binding-android-arm-eabi@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.55.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.55.0':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.70.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.70.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.70.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.70.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.70.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.70.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.70.0':
+    optional: true
+
   '@poppinss/colors@4.1.5':
     dependencies:
       kleur: 4.1.5
@@ -3022,6 +3400,52 @@ snapshots:
     dependencies:
       '@babel/parser': 7.28.5
 
+  oxfmt@0.55.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.55.0
+      '@oxfmt/binding-android-arm64': 0.55.0
+      '@oxfmt/binding-darwin-arm64': 0.55.0
+      '@oxfmt/binding-darwin-x64': 0.55.0
+      '@oxfmt/binding-freebsd-x64': 0.55.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.55.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.55.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.55.0
+      '@oxfmt/binding-linux-arm64-musl': 0.55.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.55.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.55.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.55.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.55.0
+      '@oxfmt/binding-linux-x64-gnu': 0.55.0
+      '@oxfmt/binding-linux-x64-musl': 0.55.0
+      '@oxfmt/binding-openharmony-arm64': 0.55.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.55.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.55.0
+      '@oxfmt/binding-win32-x64-msvc': 0.55.0
+
+  oxlint@1.70.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.70.0
+      '@oxlint/binding-android-arm64': 1.70.0
+      '@oxlint/binding-darwin-arm64': 1.70.0
+      '@oxlint/binding-darwin-x64': 1.70.0
+      '@oxlint/binding-freebsd-x64': 1.70.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.70.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.70.0
+      '@oxlint/binding-linux-arm64-gnu': 1.70.0
+      '@oxlint/binding-linux-arm64-musl': 1.70.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.70.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.70.0
+      '@oxlint/binding-linux-riscv64-musl': 1.70.0
+      '@oxlint/binding-linux-s390x-gnu': 1.70.0
+      '@oxlint/binding-linux-x64-gnu': 1.70.0
+      '@oxlint/binding-linux-x64-musl': 1.70.0
+      '@oxlint/binding-openharmony-arm64': 1.70.0
+      '@oxlint/binding-win32-arm64-msvc': 1.70.0
+      '@oxlint/binding-win32-ia32-msvc': 1.70.0
+      '@oxlint/binding-win32-x64-msvc': 1.70.0
+
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
@@ -3193,6 +3617,8 @@ snapshots:
       picomatch: 4.0.3
 
   tinypool@1.1.1: {}
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@2.0.0: {}
 

--- a/scripts/db-seed.ts
+++ b/scripts/db-seed.ts
@@ -63,9 +63,6 @@ console.log("cat > migrations/seed.sql << 'EOF'");
 console.log(seedSQL);
 console.log("EOF\n");
 console.log("# ローカルで実行");
-console.log(
-  "wrangler d1 execute gidoku-db --local --file=migrations/seed.sql\n"
-);
+console.log("wrangler d1 execute gidoku-db --local --file=migrations/seed.sql\n");
 console.log("# 本番で実行（注意！）");
 console.log("wrangler d1 execute gidoku-db --file=migrations/seed.sql\n");
-

--- a/scripts/db-setup.ts
+++ b/scripts/db-setup.ts
@@ -31,9 +31,7 @@ function generateMigrationCommands(): string[] {
 
   migrations.forEach((migration) => {
     console.log(`📄 Migration: ${migration.name}`);
-    commands.push(
-      `wrangler d1 execute gidoku-db --local --file=migrations/${migration.name}`
-    );
+    commands.push(`wrangler d1 execute gidoku-db --local --file=migrations/${migration.name}`);
   });
 
   return commands;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,19 @@
-import build from '@hono/vite-build/cloudflare-workers'
-import adapter from '@hono/vite-dev-server/cloudflare'
-import tailwindcss from '@tailwindcss/vite'
-import honox from 'honox/vite'
-import { defineConfig } from 'vite'
+import build from "@hono/vite-build/cloudflare-workers";
+import adapter from "@hono/vite-dev-server/cloudflare";
+import tailwindcss from "@tailwindcss/vite";
+import honox from "honox/vite";
+import { defineConfig } from "vite";
 
 export default defineConfig(({ mode }) => ({
   plugins: [
     honox({
       devServer: { adapter },
-      client: { input: ['/app/client.ts', '/app/style.css'] }
+      client: { input: ["/app/client.ts", "/app/style.css"] },
     }),
     tailwindcss(),
-    build()
+    build(),
   ],
   esbuild: {
-    jsxImportSource: mode === 'client' ? 'hono/jsx/dom' : 'hono/jsx'
-  }
-}))
+    jsxImportSource: mode === "client" ? "hono/jsx/dom" : "hono/jsx",
+  },
+}));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,18 +1,18 @@
-import { defineWorkersProject } from '@cloudflare/vitest-pool-workers/config'
+import { defineWorkersProject } from "@cloudflare/vitest-pool-workers/config";
 
 export default defineWorkersProject({
   test: {
     globals: true,
-    include: ['app/**/*.test.ts'],
-    setupFiles: ['./app/test/setup.ts'],
+    include: ["app/**/*.test.ts"],
+    setupFiles: ["./app/test/setup.ts"],
     poolOptions: {
       workers: {
-        wrangler: { configPath: './wrangler.test.jsonc' },
+        wrangler: { configPath: "./wrangler.test.jsonc" },
         miniflare: {
-          d1Databases: ['DB'],
-          kvNamespaces: ['KV'],
+          d1Databases: ["DB"],
+          kvNamespaces: ["KV"],
         },
       },
     },
   },
-})
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,27 +5,27 @@
   "compatibility_date": "2025-12-09",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
   },
   "d1_databases": [
     {
       "binding": "DB",
       "database_name": "gidoku-db",
-      "database_id": "49c64334-1ca7-4841-9b35-9d5a33ec2cd4"
-    }
+      "database_id": "49c64334-1ca7-4841-9b35-9d5a33ec2cd4",
+    },
   ],
   "kv_namespaces": [
     {
       "binding": "KV",
       "id": "ff87f54f4b8844168840502656699f37",
-      "preview_id": "fe6ec6f0a8c548509522d4fd958bb9fa"
-    }
+      "preview_id": "fe6ec6f0a8c548509522d4fd958bb9fa",
+    },
   ],
   "vars": {
     "GITHUB_CLIENT_ID": "Ov23li1W8sYXe7C1fWlR",
     "GOOGLE_CLIENT_ID": "494336925174-ovnmt0b3ssdfqfvgtm1n28va40oau4n1.apps.googleusercontent.com",
-    "APP_URL": "https://gidoku.com"
-  }
+    "APP_URL": "https://gidoku.com",
+  },
   // "r2_buckets": [
   //   {
   //     "binding": "MY_BUCKET",

--- a/wrangler.staging.jsonc
+++ b/wrangler.staging.jsonc
@@ -1,36 +1,34 @@
 {
-	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "gidoku-com-staging",
-	"main": "./dist/index.js",
-	"compatibility_date": "2025-12-09",
-	"compatibility_flags": [
-		"nodejs_compat"
-	],
-	"assets": {
-		"directory": "./dist"
-	},
-	"d1_databases": [
-		{
-			"binding": "DB",
-			"database_name": "gidoku-db-staging",
-			"database_id": "12802069-e41c-41f6-aa59-7a339d9f0744"
-		}
-	],
-	"kv_namespaces": [
-		{
-			"binding": "KV",
-			"id": "1378483b23f24cd59870e141a9634716",
-		}
-	],
-	"vars": {
-		"GITHUB_CLIENT_ID": "Ov23liq4okvsI8w6kVsC",
-		"GOOGLE_CLIENT_ID": "494336925174-q3f41lih9r2o58unehpr312oncl3mdft.apps.googleusercontent.com",
-		"APP_URL": "https://staging.gidoku.com"
-	},
-	"routes": [
-		{
-			"pattern": "staging.gidoku.com",
-			"custom_domain": true
-		}
-	]
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "gidoku-com-staging",
+  "main": "./dist/index.js",
+  "compatibility_date": "2025-12-09",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "directory": "./dist",
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "gidoku-db-staging",
+      "database_id": "12802069-e41c-41f6-aa59-7a339d9f0744",
+    },
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "KV",
+      "id": "1378483b23f24cd59870e141a9634716",
+    },
+  ],
+  "vars": {
+    "GITHUB_CLIENT_ID": "Ov23liq4okvsI8w6kVsC",
+    "GOOGLE_CLIENT_ID": "494336925174-q3f41lih9r2o58unehpr312oncl3mdft.apps.googleusercontent.com",
+    "APP_URL": "https://staging.gidoku.com",
+  },
+  "routes": [
+    {
+      "pattern": "staging.gidoku.com",
+      "custom_domain": true,
+    },
+  ],
 }

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -7,19 +7,19 @@
     {
       "binding": "DB",
       "database_name": "gidoku-db",
-      "database_id": "49c64334-1ca7-4841-9b35-9d5a33ec2cd4"
-    }
+      "database_id": "49c64334-1ca7-4841-9b35-9d5a33ec2cd4",
+    },
   ],
   "kv_namespaces": [
     {
       "binding": "KV",
       "id": "ff87f54f4b8844168840502656699f37",
-      "preview_id": "fe6ec6f0a8c548509522d4fd958bb9fa"
-    }
+      "preview_id": "fe6ec6f0a8c548509522d4fd958bb9fa",
+    },
   ],
   "vars": {
     "GITHUB_CLIENT_ID": "Ov23li1W8sYXe7C1fWlR",
     "GOOGLE_CLIENT_ID": "494336925174-ovnmt0b3ssdfqfvgtm1n28va40oau4n1.apps.googleusercontent.com",
-    "APP_URL": "https://gidoku.com"
-  }
+    "APP_URL": "https://gidoku.com",
+  },
 }


### PR DESCRIPTION
## 概要
- `oxlint` / `oxfmt` を lint / format 用ツールチェーンとして追加
- Oxc の設定ファイルと `package.json` scripts を追加
- CI を `typecheck`, `lint`, `format`, `test` の job に分割して、失敗箇所を追いやすくした
- 初回の `oxfmt` を適用し、`oxlint` の error を修正

## 確認
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run test`

## 補足
- `oxlint` の warning は既存コード由来のため、この PR では error のみ修正しています。
- ローカル sandbox 内では Cloudflare Vitest pool の起動で失敗しましたが、権限付き実行では `pnpm run test` が通過しています。