### PR TITLE
lint warningで見つかった箇所をなおす

### DIFF
--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -1,4 +1,4 @@
-import type {} from "hono";
+import "hono";
 import type { Env as AppEnv, Variables as AppVariables } from "./types/env";
 
 declare module "hono" {

--- a/app/islands/IconCloud.tsx
+++ b/app/islands/IconCloud.tsx
@@ -99,17 +99,21 @@ export default function IconCloud({ images, width = 400, height = 400 }: IconClo
         const img = new Image();
         img.crossOrigin = "anonymous";
         img.src = imageUrl;
-        img.onload = () => {
-          offCtx.clearRect(0, 0, offscreen.width, offscreen.height);
+        img.addEventListener(
+          "load",
+          () => {
+            offCtx.clearRect(0, 0, offscreen.width, offscreen.height);
 
-          // Draw the image slightly smaller (80% of size) with transparent background
-          const padding = iconSize * 0.1; // 10% padding on each side
-          offCtx.drawImage(img, padding, padding, iconSize - padding * 2, iconSize - padding * 2);
+            // Draw the image slightly smaller (80% of size) with transparent background
+            const padding = iconSize * 0.1; // 10% padding on each side
+            offCtx.drawImage(img, padding, padding, iconSize - padding * 2, iconSize - padding * 2);
 
-          if (imagesLoadedRef.current) {
-            imagesLoadedRef.current[index] = true;
-          }
-        };
+            if (imagesLoadedRef.current) {
+              imagesLoadedRef.current[index] = true;
+            }
+          },
+          { once: true },
+        );
       }
       return offscreen;
     });
@@ -283,7 +287,7 @@ export default function IconCloud({ images, width = 400, height = 400 }: IconClo
 
       // Sort icons by z-depth for proper rendering order
       const rotation = rotationRef.current ?? { x: 0, y: 0 };
-      const sortedIcons = [...iconPositions].map((icon) => {
+      const sortedIcons = iconPositions.map((icon) => {
         const cosX = Math.cos(rotation.x);
         const sinX = Math.sin(rotation.x);
         const cosY = Math.cos(rotation.y);
@@ -293,7 +297,17 @@ export default function IconCloud({ images, width = 400, height = 400 }: IconClo
         const rotatedZ = icon.x * sinY + icon.z * cosY;
         const rotatedY = icon.y * cosX + rotatedZ * sinX;
 
-        return { ...icon, rotatedX, rotatedY, rotatedZ };
+        return {
+          x: icon.x,
+          y: icon.y,
+          z: icon.z,
+          scale: icon.scale,
+          opacity: icon.opacity,
+          id: icon.id,
+          rotatedX,
+          rotatedY,
+          rotatedZ,
+        };
       });
 
       sortedIcons.sort((a, b) => a.rotatedZ - b.rotatedZ);

--- a/app/routes/books/index.tsx
+++ b/app/routes/books/index.tsx
@@ -6,6 +6,18 @@ import BooksStatusTabs from "../../islands/BooksStatusTabs";
 import { bookRepo } from "../../server/db/repositories";
 import type { Book, BookStatus } from "../../types/database";
 
+const formatBooks = (bookList: Book[]) =>
+  bookList.map((book) => ({
+    id: book.id,
+    title: book.title,
+    authors: JSON.parse(book.authors),
+    publisher: book.publisher,
+    thumbnailUrl: book.thumbnail_url,
+    status: book.status,
+    currentPage: book.current_page,
+    pageCount: book.page_count,
+  }));
+
 export default createRoute(async (c) => {
   const authResult = await requirePageAuth(c);
   if (authResult instanceof Response) {
@@ -24,18 +36,6 @@ export default createRoute(async (c) => {
     limit: 50,
     offset: 0,
   });
-
-  const formatBooks = (books: Book[]) =>
-    books.map((book) => ({
-      id: book.id,
-      title: book.title,
-      authors: JSON.parse(book.authors),
-      publisher: book.publisher,
-      thumbnailUrl: book.thumbnail_url,
-      status: book.status,
-      currentPage: book.current_page,
-      pageCount: book.page_count,
-    }));
 
   return c.render(
     <Layout user={user} title="My Books" sidebarExpanded={sidebarExpanded}>

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -8,6 +8,18 @@ import { bookRepo } from "../server/db/repositories";
 import { BookCover } from "../components/book/BookCover";
 import type { Book } from "../types/database";
 
+const formatBooks = (bookList: Book[]) =>
+  bookList.map((book) => ({
+    id: book.id,
+    title: book.title,
+    authors: JSON.parse(book.authors),
+    publisher: book.publisher,
+    thumbnailUrl: book.thumbnail_url,
+    status: book.status,
+    currentPage: book.current_page,
+    pageCount: book.page_count,
+  }));
+
 export default createRoute(async (c) => {
   const user = await getPageUser(c);
   const sidebarExpanded = getSidebarExpanded(c);
@@ -162,18 +174,6 @@ export default createRoute(async (c) => {
     limit: 6,
     offset: 0,
   });
-
-  const formatBooks = (books: Book[]) =>
-    books.map((book) => ({
-      id: book.id,
-      title: book.title,
-      authors: JSON.parse(book.authors),
-      publisher: book.publisher,
-      thumbnailUrl: book.thumbnail_url,
-      status: book.status,
-      currentPage: book.current_page,
-      pageCount: book.page_count,
-    }));
 
   const formattedReadingBooks = formatBooks(readingBooks);
 

--- a/app/server/api/users.ts
+++ b/app/server/api/users.ts
@@ -96,11 +96,11 @@ app.get("/:username/books", optionalAuthMiddleware, async (c) => {
 
   return successResponse(
     c,
-    books.map((book) => ({
-      ...toBookResponse(book),
-      // 公開用に一部フィールドを隠す
-      memo: null,
-    })),
+    books.map((book) => {
+      const response = toBookResponse(book);
+      response.memo = null;
+      return response;
+    }),
   );
 });
 


### PR DESCRIPTION
## 概要
- `oxlint` の warning で見つかった箇所のうち、実際に可読性・保守性改善になるものを修正した
- `IconCloud` の image load handler を `addEventListener` に変更し、map 内の object spread を避ける形に変更
- 書籍表示用の `formatBooks` を route handler 外へ移動し、shadowing を解消
- Hono の型拡張用 import を bare import に変更
- 公開書籍レスポンスの `memo` マスク処理で map 内の object spread を避ける形に変更

## 確認
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run test`