### PR TITLE
型でドメインモデルを表現する

### DIFF
--- a/app/routes/books/[id]/edit.tsx
+++ b/app/routes/books/[id]/edit.tsx
@@ -4,6 +4,7 @@ import { Layout } from "../../../components/layout/Layout";
 import { Input, Textarea, Label } from "../../../components/ui/Input";
 import { Button } from "../../../components/ui/Button";
 import { bookRepo } from "../../../server/db/repositories";
+import type { BookId } from "../../../types/domain";
 
 export default createRoute(async (c) => {
   const authResult = await requirePageAuth(c);
@@ -13,7 +14,7 @@ export default createRoute(async (c) => {
   const user = authResult;
   const sidebarExpanded = getSidebarExpanded(c);
 
-  const id = c.req.param("id")!;
+  const id = c.req.param("id")! as BookId;
 
   let book;
   try {

--- a/app/routes/books/[id]/index.tsx
+++ b/app/routes/books/[id]/index.tsx
@@ -4,6 +4,7 @@ import { Layout } from "../../../components/layout/Layout";
 import { BookCover } from "../../../components/book/BookCover";
 import { Button } from "../../../components/ui/Button";
 import { bookRepo } from "../../../server/db/repositories";
+import type { BookId } from "../../../types/domain";
 import ProgressSlider from "../../../islands/ProgressSlider";
 import StatusToggle from "../../../islands/StatusToggle";
 import MemoEditor from "../../../islands/MemoEditor";
@@ -16,7 +17,7 @@ export default createRoute(async (c) => {
   const user = authResult;
   const sidebarExpanded = getSidebarExpanded(c);
 
-  const id = c.req.param("id")!;
+  const id = c.req.param("id")! as BookId;
 
   let book;
   try {

--- a/app/server/api/auth.ts
+++ b/app/server/api/auth.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { setCookie, deleteCookie, getCookie } from "hono/cookie";
 import type { HonoContext } from "../../types/env";
+import type { UserId } from "../../types/domain";
 import { userRepo } from "../db/repositories";
 import { authMiddleware } from "../lib/auth";
 import { validator, getValidated } from "../lib/validator";
@@ -102,7 +103,7 @@ app.get(
         // 新規ユーザー作成
         const now = new Date().toISOString();
         user = await userRepo.create(c.env.DB, {
-          id: crypto.randomUUID(),
+          id: crypto.randomUUID() as UserId,
           username: await generateUniqueUsername(c.env.DB, oauthUser.username),
           email: oauthUser.email,
           name: oauthUser.name,

--- a/app/server/api/books.test.ts
+++ b/app/server/api/books.test.ts
@@ -4,10 +4,11 @@ import api from "./index";
 import { createTestUser, createTestSession, createTestBook } from "../../test/helpers";
 import type { SuccessResponse, PaginatedResponse } from "../lib/response";
 import type { BookResponse } from "../../types/database";
+import type { UserId, SessionId } from "../../types/domain";
 
 describe("Books API Integration", () => {
-  let userId: string;
-  let sessionId: string;
+  let userId: UserId;
+  let sessionId: SessionId;
 
   beforeEach(async () => {
     await env.DB.prepare("DELETE FROM book_tags").run();

--- a/app/server/api/books.ts
+++ b/app/server/api/books.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { HonoContext } from "../../types/env";
+import type { BookId } from "../../types/domain";
 import { bookRepo, bookTagRepo } from "../db/repositories";
 import { authMiddleware } from "../lib/auth";
 import { validator, getValidated } from "../lib/validator";
@@ -47,10 +48,6 @@ app.get("/", validator("query", bookFilterSchema), async (c) => {
 });
 
 /**
- * 書籍詳細取得
- * GET /api/books/:id
- */
-/**
  * 書籍統計取得
  * GET /api/books/stats
  */
@@ -69,8 +66,8 @@ app.get("/:id", validator("param", bookIdSchema), async (c) => {
   const userId = c.get("userId");
   const { id } = getValidated<{ id: string }>(c, "param");
 
-  const book = await bookRepo.findById(c.env.DB, id, userId);
-  const tags = await bookTagRepo.findTagsByBookId(c.env.DB, id);
+  const book = await bookRepo.findById(c.env.DB, id as BookId, userId);
+  const tags = await bookTagRepo.findTagsByBookId(c.env.DB, id as BookId);
 
   return successResponse(c, {
     ...toBookResponse(book),
@@ -106,7 +103,7 @@ app.put(
     const data = getValidated<UpdateBookInput>(c, "json");
 
     const updateData = toBookUpdateInput(data);
-    const book = await bookRepo.update(c.env.DB, id, userId, updateData);
+    const book = await bookRepo.update(c.env.DB, id as BookId, userId, updateData);
 
     return successResponse(c, toBookResponse(book));
   },
@@ -126,7 +123,7 @@ app.patch(
     const { currentPage } = getValidated<ProgressInput>(c, "json");
 
     // 書籍を取得してページ数を検証
-    const existingBook = await bookRepo.findById(c.env.DB, id, userId);
+    const existingBook = await bookRepo.findById(c.env.DB, id as BookId, userId);
     const validation = bookDomain.validatePageProgress(currentPage, existingBook.page_count);
 
     if (!validation.valid) {
@@ -141,7 +138,7 @@ app.patch(
       ? new Date().toISOString()
       : existingBook.finished_at;
 
-    const book = await bookRepo.update(c.env.DB, id, userId, {
+    const book = await bookRepo.update(c.env.DB, id as BookId, userId, {
       currentPage: currentPage,
       status: newStatus,
       finishedAt,
@@ -160,7 +157,7 @@ app.delete("/:id", validator("param", bookIdSchema), async (c) => {
   const userId = c.get("userId");
   const { id } = getValidated<{ id: string }>(c, "param");
 
-  await bookRepo.deleteById(c.env.DB, id, userId);
+  await bookRepo.deleteById(c.env.DB, id as BookId, userId);
 
   return successResponse(c, { deleted: true });
 });

--- a/app/server/api/schemas/auth.ts
+++ b/app/server/api/schemas/auth.ts
@@ -1,5 +1,7 @@
 import { regex, type } from "arktype";
 
+export type { OAuthProvider } from "../../../types/domain";
+
 /**
  * OAuth認証プロバイダー
  */
@@ -26,7 +28,7 @@ export const oauthCallbackSchema = type({
 export const rakutenSearchSchema = type({
   query: "1 <= string <= 100",
   "limit?": "1 <= (number % 1) <= 10",
-  "page?": "1 <= (number % 1) <= 1000", // 追加
+  "page?": "1 <= (number % 1) <= 1000",
 });
 
 /**
@@ -39,7 +41,6 @@ export const isbnSearchSchema = type({
 });
 
 // 型エクスポート
-export type OAuthProvider = typeof oauthProviderSchema.infer;
 export type OAuthProviderParam = typeof oauthProviderParamSchema.infer;
 export type OAuthCallbackInput = typeof oauthCallbackSchema.infer;
 export type RakutenSearchInput = typeof rakutenSearchSchema.infer;

--- a/app/server/api/tags.test.ts
+++ b/app/server/api/tags.test.ts
@@ -9,10 +9,11 @@ import {
 } from "../../test/helpers";
 import type { SuccessResponse } from "../lib/response";
 import type { TagResponse } from "../../types/database";
+import type { UserId, SessionId } from "../../types/domain";
 
 describe("Tags API Integration", () => {
-  let userId: string;
-  let sessionId: string;
+  let userId: UserId;
+  let sessionId: SessionId;
 
   beforeEach(async () => {
     await env.DB.prepare("DELETE FROM book_tags").run();

--- a/app/server/api/tags.ts
+++ b/app/server/api/tags.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { HonoContext } from "../../types/env";
+import type { BookId, TagId } from "../../types/domain";
 import { tagRepo, bookTagRepo } from "../db/repositories";
 import { authMiddleware } from "../lib/auth";
 import { validator, getValidated } from "../lib/validator";
@@ -53,7 +54,7 @@ app.put("/:id", validator("param", tagIdSchema), validator("json", updateTagSche
   const { id } = getValidated<{ id: string }>(c, "param");
   const data = getValidated<UpdateTagInput>(c, "json");
 
-  const tag = await tagRepo.update(c.env.DB, id, userId, data.name);
+  const tag = await tagRepo.update(c.env.DB, id as TagId, userId, data.name);
 
   return successResponse(c, toTagResponse(tag));
 });
@@ -66,7 +67,7 @@ app.delete("/:id", validator("param", tagIdSchema), async (c) => {
   const userId = c.get("userId");
   const { id } = getValidated<{ id: string }>(c, "param");
 
-  await tagRepo.deleteById(c.env.DB, id, userId);
+  await tagRepo.deleteById(c.env.DB, id as TagId, userId);
 
   return successResponse(c, { deleted: true });
 });
@@ -84,7 +85,7 @@ app.post(
     const { bookId } = getValidated<{ bookId: string }>(c, "param");
     const { tagId } = getValidated<AddTagToBookInput>(c, "json");
 
-    await bookTagRepo.addTagToBook(c.env.DB, bookId, tagId, userId);
+    await bookTagRepo.addTagToBook(c.env.DB, bookId as BookId, tagId as TagId, userId);
 
     return successResponse(c, { added: true }, 201);
   },
@@ -99,7 +100,7 @@ app.delete("/books/:bookId/:tagId", async (c) => {
   const bookId = c.req.param("bookId");
   const tagId = c.req.param("tagId");
 
-  await bookTagRepo.removeTagFromBook(c.env.DB, bookId, tagId, userId);
+  await bookTagRepo.removeTagFromBook(c.env.DB, bookId as BookId, tagId as TagId, userId);
 
   return successResponse(c, { removed: true });
 });
@@ -111,7 +112,7 @@ app.delete("/books/:bookId/:tagId", async (c) => {
 app.get("/books/:bookId", async (c) => {
   const bookId = c.req.param("bookId");
 
-  const tags = await bookTagRepo.findTagsByBookId(c.env.DB, bookId);
+  const tags = await bookTagRepo.findTagsByBookId(c.env.DB, bookId as BookId);
 
   return successResponse(c, tags.map(toTagResponse));
 });

--- a/app/server/db/repositories/book.test.ts
+++ b/app/server/db/repositories/book.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { env } from "cloudflare:test";
 import * as bookRepo from "./book";
 import { createTestUser, createTestBook } from "../../../test/helpers";
+import type { UserId, BookId } from "../../../types/domain";
 
 describe("Book Repository", () => {
-  let userId: string;
+  let userId: UserId;
 
   beforeEach(async () => {
     // テストデータをクリーンアップ
@@ -21,7 +22,7 @@ describe("Book Repository", () => {
   describe("create", () => {
     it("should create a book", async () => {
       const now = new Date().toISOString();
-      const bookId = crypto.randomUUID();
+      const bookId = crypto.randomUUID() as BookId;
 
       const book = await bookRepo.create(env.DB, {
         id: bookId,
@@ -51,9 +52,9 @@ describe("Book Repository", () => {
     });
 
     it("should throw NotFoundError for non-existent book", async () => {
-      await expect(bookRepo.findById(env.DB, "non-existent", userId)).rejects.toThrow(
-        "Book not found",
-      );
+      await expect(
+        bookRepo.findById(env.DB, "non-existent" as BookId, userId),
+      ).rejects.toThrow("Book not found");
     });
 
     it("should not return books from other users", async () => {

--- a/app/server/db/repositories/book.ts
+++ b/app/server/db/repositories/book.ts
@@ -1,7 +1,9 @@
-import type { Book, BookInput, BookFilter, BookStats, BookStatus } from "../../../types/database";
+import type { Book, BookInput, BookFilter, BookStats } from "../../../types/database";
+import type { BookStatus } from "../../../types/domain";
 import { NotFoundError, DatabaseError } from "../../lib/errors";
 
 import type { Env } from "../../../types/env";
+import type { UserId, BookId } from "../../../types/domain";
 
 type D1Database = Env["DB"];
 type D1BindValue = string | number | null;
@@ -11,7 +13,7 @@ type D1BindValue = string | number | null;
  */
 export async function findByUserId(
   db: D1Database,
-  userId: string,
+  userId: UserId,
   filter?: BookFilter & { limit?: number; offset?: number },
 ): Promise<{ books: Book[]; total: number }> {
   try {
@@ -82,7 +84,7 @@ export async function findByUserId(
 /**
  * IDで書籍を取得
  */
-export async function findById(db: D1Database, bookId: string, userId: string): Promise<Book> {
+export async function findById(db: D1Database, bookId: BookId, userId: UserId): Promise<Book> {
   try {
     const result = await db
       .prepare("SELECT * FROM books WHERE id = ? AND user_id = ?")
@@ -149,8 +151,8 @@ export async function create(db: D1Database, book: BookInput): Promise<Book> {
  */
 export async function update(
   db: D1Database,
-  bookId: string,
-  userId: string,
+  bookId: BookId,
+  userId: UserId,
   data: Partial<BookInput>,
 ): Promise<Book> {
   try {
@@ -210,8 +212,8 @@ export async function update(
  */
 export async function updateProgress(
   db: D1Database,
-  bookId: string,
-  userId: string,
+  bookId: BookId,
+  userId: UserId,
   currentPage: number,
   status: BookStatus,
 ): Promise<Book> {
@@ -240,7 +242,7 @@ export async function updateProgress(
 /**
  * 書籍を削除（関連するタグも削除）
  */
-export async function deleteById(db: D1Database, bookId: string, userId: string): Promise<void> {
+export async function deleteById(db: D1Database, bookId: BookId, userId: UserId): Promise<void> {
   try {
     // 書籍の存在確認
     await findById(db, bookId, userId);
@@ -259,7 +261,7 @@ export async function deleteById(db: D1Database, bookId: string, userId: string)
 /**
  * ユーザーの統計情報を取得
  */
-export async function getStats(db: D1Database, userId: string): Promise<BookStats> {
+export async function getStats(db: D1Database, userId: UserId): Promise<BookStats> {
   try {
     const result = await db
       .prepare(
@@ -294,8 +296,8 @@ export async function getStats(db: D1Database, userId: string): Promise<BookStat
  */
 export async function belongsToUser(
   db: D1Database,
-  bookId: string,
-  userId: string,
+  bookId: BookId,
+  userId: UserId,
 ): Promise<boolean> {
   try {
     const result = await db

--- a/app/server/db/repositories/bookTag.test.ts
+++ b/app/server/db/repositories/bookTag.test.ts
@@ -7,11 +7,12 @@ import {
   createTestUser,
   cleanupDatabase,
 } from "../../../test/helpers";
+import type { UserId, BookId, TagId } from "../../../types/domain";
 
 describe("BookTag Repository", () => {
-  let userId: string;
-  let bookId: string;
-  let tagId: string;
+  let userId: UserId;
+  let bookId: BookId;
+  let tagId: TagId;
 
   beforeEach(async () => {
     await cleanupDatabase(env.DB);
@@ -47,15 +48,15 @@ describe("BookTag Repository", () => {
   });
 
   it("should reject adding tag for missing book", async () => {
-    await expect(bookTagRepo.addTagToBook(env.DB, "missing-book", tagId, userId)).rejects.toThrow(
-      "Book not found",
-    );
+    await expect(
+      bookTagRepo.addTagToBook(env.DB, "missing-book" as BookId, tagId, userId),
+    ).rejects.toThrow("Book not found");
   });
 
   it("should reject adding tag for missing tag", async () => {
-    await expect(bookTagRepo.addTagToBook(env.DB, bookId, "missing-tag", userId)).rejects.toThrow(
-      "Tag not found",
-    );
+    await expect(
+      bookTagRepo.addTagToBook(env.DB, bookId, "missing-tag" as TagId, userId),
+    ).rejects.toThrow("Tag not found");
   });
 
   it("should reject adding tag for other user book", async () => {

--- a/app/server/db/repositories/bookTag.ts
+++ b/app/server/db/repositories/bookTag.ts
@@ -1,6 +1,7 @@
 import type { BookTag, Tag } from "../../../types/database";
 import { DatabaseError, NotFoundError, ForbiddenError } from "../../lib/errors";
 import type { Env } from "../../../types/env";
+import type { UserId, BookId, TagId } from "../../../types/domain";
 
 type D1Database = Env["DB"];
 
@@ -9,9 +10,9 @@ type D1Database = Env["DB"];
  */
 export async function addTagToBook(
   db: D1Database,
-  bookId: string,
-  tagId: string,
-  userId: string,
+  bookId: BookId,
+  tagId: TagId,
+  userId: UserId,
 ): Promise<void> {
   try {
     // 書籍の所有権チェック
@@ -68,9 +69,9 @@ export async function addTagToBook(
  */
 export async function removeTagFromBook(
   db: D1Database,
-  bookId: string,
-  tagId: string,
-  userId: string,
+  bookId: BookId,
+  tagId: TagId,
+  userId: UserId,
 ): Promise<void> {
   try {
     // 書籍の所有権チェック
@@ -101,7 +102,7 @@ export async function removeTagFromBook(
 /**
  * 書籍に紐づくタグ一覧を取得
  */
-export async function findTagsByBookId(db: D1Database, bookId: string): Promise<Tag[]> {
+export async function findTagsByBookId(db: D1Database, bookId: BookId): Promise<Tag[]> {
   try {
     const result = await db
       .prepare(
@@ -124,7 +125,7 @@ export async function findTagsByBookId(db: D1Database, bookId: string): Promise<
 /**
  * 書籍の全タグを削除
  */
-export async function removeAllTagsFromBook(db: D1Database, bookId: string): Promise<void> {
+export async function removeAllTagsFromBook(db: D1Database, bookId: BookId): Promise<void> {
   try {
     await db.prepare("DELETE FROM book_tags WHERE book_id = ?").bind(bookId).run();
   } catch (error) {
@@ -137,8 +138,8 @@ export async function removeAllTagsFromBook(db: D1Database, bookId: string): Pro
  */
 export async function isTagAttached(
   db: D1Database,
-  bookId: string,
-  tagId: string,
+  bookId: BookId,
+  tagId: TagId,
 ): Promise<boolean> {
   try {
     const result = await db
@@ -155,7 +156,7 @@ export async function isTagAttached(
 /**
  * 書籍に紐づくタグの数を取得
  */
-export async function countTagsByBook(db: D1Database, bookId: string): Promise<number> {
+export async function countTagsByBook(db: D1Database, bookId: BookId): Promise<number> {
   try {
     const result = await db
       .prepare("SELECT COUNT(*) as count FROM book_tags WHERE book_id = ?")
@@ -171,7 +172,7 @@ export async function countTagsByBook(db: D1Database, bookId: string): Promise<n
 /**
  * タグに紐づく書籍の数を取得
  */
-export async function countBooksByTag(db: D1Database, tagId: string): Promise<number> {
+export async function countBooksByTag(db: D1Database, tagId: TagId): Promise<number> {
   try {
     const result = await db
       .prepare("SELECT COUNT(*) as count FROM book_tags WHERE tag_id = ?")
@@ -189,8 +190,8 @@ export async function countBooksByTag(db: D1Database, tagId: string): Promise<nu
  */
 export async function updateBookTags(
   db: D1Database,
-  bookId: string,
-  tagIds: string[],
+  bookId: BookId,
+  tagIds: TagId[],
 ): Promise<void> {
   try {
     // 既存のタグを削除

--- a/app/server/db/repositories/tag.test.ts
+++ b/app/server/db/repositories/tag.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { env } from "cloudflare:test";
 import * as tagRepo from "./tag";
 import { createTestTag, createTestUser, cleanupDatabase } from "../../../test/helpers";
+import type { UserId, TagId } from "../../../types/domain";
 
 describe("Tag Repository", () => {
-  let userId: string;
+  let userId: UserId;
 
   beforeEach(async () => {
     await cleanupDatabase(env.DB);
@@ -28,7 +29,9 @@ describe("Tag Repository", () => {
   });
 
   it("should throw when tag not found", async () => {
-    await expect(tagRepo.findById(env.DB, "missing-tag", userId)).rejects.toThrow("Tag not found");
+    await expect(
+      tagRepo.findById(env.DB, "missing-tag" as TagId, userId),
+    ).rejects.toThrow("Tag not found");
   });
 
   it("should find tag by name", async () => {
@@ -45,7 +48,7 @@ describe("Tag Repository", () => {
 
   it("should create a tag", async () => {
     const created = await tagRepo.create(env.DB, {
-      id: "tag-1",
+      id: "tag-1" as TagId,
       userId,
       name: "NewTag",
       createdAt: new Date().toISOString(),
@@ -59,7 +62,7 @@ describe("Tag Repository", () => {
 
     await expect(
       tagRepo.create(env.DB, {
-        id: "tag-2",
+        id: "tag-2" as TagId,
         userId,
         name: "Duplicate",
         createdAt: new Date().toISOString(),

--- a/app/server/db/repositories/tag.ts
+++ b/app/server/db/repositories/tag.ts
@@ -1,13 +1,14 @@
 import type { Tag, TagInput } from "../../../types/database";
 import { NotFoundError, DatabaseError } from "../../lib/errors";
 import type { Env } from "../../../types/env";
+import type { UserId, TagId } from "../../../types/domain";
 
 type D1Database = Env["DB"];
 
 /**
  * ユーザーのタグ一覧を取得
  */
-export async function findByUserId(db: D1Database, userId: string): Promise<Tag[]> {
+export async function findByUserId(db: D1Database, userId: UserId): Promise<Tag[]> {
   try {
     const result = await db
       .prepare("SELECT * FROM tags WHERE user_id = ? ORDER BY name ASC")
@@ -23,7 +24,7 @@ export async function findByUserId(db: D1Database, userId: string): Promise<Tag[
 /**
  * IDでタグを取得
  */
-export async function findById(db: D1Database, tagId: string, userId: string): Promise<Tag> {
+export async function findById(db: D1Database, tagId: TagId, userId: UserId): Promise<Tag> {
   try {
     const result = await db
       .prepare("SELECT * FROM tags WHERE id = ? AND user_id = ?")
@@ -47,7 +48,7 @@ export async function findById(db: D1Database, tagId: string, userId: string): P
 export async function findByName(
   db: D1Database,
   name: string,
-  userId: string,
+  userId: UserId,
 ): Promise<Tag | null> {
   try {
     const result = await db
@@ -117,8 +118,8 @@ export async function create(db: D1Database, tag: TagInput): Promise<Tag> {
  */
 export async function update(
   db: D1Database,
-  tagId: string,
-  userId: string,
+  tagId: TagId,
+  userId: UserId,
   name: string,
 ): Promise<Tag> {
   try {
@@ -146,7 +147,7 @@ export async function update(
 /**
  * タグを削除
  */
-export async function deleteById(db: D1Database, tagId: string, userId: string): Promise<void> {
+export async function deleteById(db: D1Database, tagId: TagId, userId: UserId): Promise<void> {
   try {
     // タグの存在確認
     await findById(db, tagId, userId);
@@ -164,8 +165,8 @@ export async function deleteById(db: D1Database, tagId: string, userId: string):
  */
 export async function belongsToUser(
   db: D1Database,
-  tagId: string,
-  userId: string,
+  tagId: TagId,
+  userId: UserId,
 ): Promise<boolean> {
   try {
     const result = await db

--- a/app/server/db/repositories/user.test.ts
+++ b/app/server/db/repositories/user.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { env } from "cloudflare:test";
 import * as userRepo from "./user";
 import { createTestUser, cleanupDatabase } from "../../../test/helpers";
+import type { UserId } from "../../../types/domain";
 
 describe("User Repository", () => {
   beforeEach(async () => {
@@ -16,7 +17,9 @@ describe("User Repository", () => {
   });
 
   it("should throw when user id is missing", async () => {
-    await expect(userRepo.findById(env.DB, "missing-user-id")).rejects.toThrow("User not found");
+    await expect(userRepo.findById(env.DB, "missing-user-id" as UserId)).rejects.toThrow(
+      "User not found",
+    );
   });
 
   it("should find user by username", async () => {
@@ -55,7 +58,7 @@ describe("User Repository", () => {
   it("should create a new user", async () => {
     const now = new Date().toISOString();
     const created = await userRepo.create(env.DB, {
-      id: "user-1",
+      id: "user-1" as UserId,
       username: "new_user",
       email: "new_user@example.com",
       name: "New User",
@@ -77,7 +80,7 @@ describe("User Repository", () => {
 
     await expect(
       userRepo.create(env.DB, {
-        id: "user-2",
+        id: "user-2" as UserId,
         username: "dupe",
         email: "dupe@example.com",
         name: "Dupe",

--- a/app/server/db/repositories/user.ts
+++ b/app/server/db/repositories/user.ts
@@ -1,6 +1,7 @@
 import { DatabaseError, NotFoundError } from "../../lib/errors";
 import type { User, UserInput } from "../../../types/database";
 import type { Env } from "../../../types/env";
+import type { UserId } from "../../../types/domain";
 
 type D1Database = Env["DB"];
 type D1BindValue = string | number | null;
@@ -8,7 +9,7 @@ type D1BindValue = string | number | null;
 /**
  * IDでユーザーを取得
  */
-export async function findById(db: D1Database, userId: string): Promise<User> {
+export async function findById(db: D1Database, userId: UserId): Promise<User> {
   try {
     const result = await db.prepare("SELECT * FROM users WHERE id = ?").bind(userId).first<User>();
 
@@ -86,7 +87,7 @@ export async function findByProvider(
 export async function isUsernameTaken(
   db: D1Database,
   username: string,
-  excludeUserId?: string,
+  excludeUserId?: UserId,
 ): Promise<boolean> {
   try {
     let query = "SELECT id FROM users WHERE username = ?";
@@ -154,7 +155,7 @@ export async function create(db: D1Database, user: UserInput): Promise<User> {
  */
 export async function update(
   db: D1Database,
-  userId: string,
+  userId: UserId,
   data: Partial<UserInput>,
 ): Promise<User> {
   try {
@@ -212,7 +213,7 @@ export async function update(
 /**
  * ユーザーを削除
  */
-export async function deleteById(db: D1Database, userId: string): Promise<void> {
+export async function deleteById(db: D1Database, userId: UserId): Promise<void> {
   try {
     // ユーザーの存在確認
     await findById(db, userId);

--- a/app/server/domain/book.ts
+++ b/app/server/domain/book.ts
@@ -1,4 +1,4 @@
-import type { BookStatus } from "../../types/database";
+import type { BookStatus } from "../../types/domain";
 
 /**
  * 進捗に基づいてステータスを計算

--- a/app/server/lib/auth.test.ts
+++ b/app/server/lib/auth.test.ts
@@ -4,6 +4,7 @@ import { env } from "cloudflare:test";
 import { authMiddleware, optionalAuthMiddleware, invalidateUserCache } from "./auth";
 import { createTestSession, createTestUser, cleanupDatabase } from "../../test/helpers";
 import type { HonoContext } from "../../types/env";
+import type { UserId } from "../../types/domain";
 
 describe("Auth middleware", () => {
   const warnSpy = vi.spyOn(console, "warn");
@@ -68,7 +69,7 @@ describe("Auth middleware", () => {
 
   it("should invalidate cached user", async () => {
     await env.KV.put("user_cache:user-1", JSON.stringify({ id: "user-1" }));
-    await invalidateUserCache(env.KV, "user-1");
+    await invalidateUserCache(env.KV, "user-1" as UserId);
     const cached = await env.KV.get("user_cache:user-1");
     expect(cached).toBeNull();
   });

--- a/app/server/lib/auth.ts
+++ b/app/server/lib/auth.ts
@@ -2,6 +2,7 @@ import type { Context, Next } from "hono";
 import { getCookie } from "hono/cookie";
 import type { Env, HonoContext } from "../../types/env";
 import type { User } from "../../types/database";
+import type { UserId } from "../../types/domain";
 import { userRepo } from "../db/repositories";
 import { validateSession } from "./session";
 import { UnauthorizedError } from "./errors";
@@ -14,7 +15,7 @@ const USER_CACHE_TTL = 300; // 5分
 /**
  * キャッシュからユーザー情報を取得
  */
-async function getCachedUser(kv: KVNamespace, userId: string): Promise<User | null> {
+async function getCachedUser(kv: KVNamespace, userId: UserId): Promise<User | null> {
   try {
     const cached = await kv.get(`user_cache:${userId}`);
     if (cached) {
@@ -42,7 +43,7 @@ async function setCachedUser(kv: KVNamespace, user: User): Promise<void> {
 /**
  * ユーザーキャッシュを無効化
  */
-export async function invalidateUserCache(kv: KVNamespace, userId: string): Promise<void> {
+export async function invalidateUserCache(kv: KVNamespace, userId: UserId): Promise<void> {
   try {
     await kv.delete(`user_cache:${userId}`);
   } catch {
@@ -146,7 +147,7 @@ export async function adminMiddleware(
 /**
  * リソース所有権チェック
  */
-export function checkOwnership(userId: string, resourceUserId: string): void {
+export function checkOwnership(userId: UserId, resourceUserId: UserId): void {
   if (userId !== resourceUserId) {
     throw new UnauthorizedError("You don't have permission to access this resource");
   }

--- a/app/server/lib/mapper.ts
+++ b/app/server/lib/mapper.ts
@@ -8,6 +8,7 @@ import type {
   User,
   UserResponse,
 } from "../../types/database";
+import type { UserId, BookId, TagId } from "../../types/domain";
 import type { CreateBookInput, UpdateBookInput } from "../api/schemas/book";
 import type { CreateTagInput } from "../api/schemas/tag";
 import { removeUndefined } from "./utils";
@@ -15,10 +16,10 @@ import { removeUndefined } from "./utils";
 /**
  * API入力からBookInputへ変換
  */
-export function toBookInput(data: CreateBookInput, userId: string): BookInput {
+export function toBookInput(data: CreateBookInput, userId: UserId): BookInput {
   const now = new Date().toISOString();
   return {
-    id: crypto.randomUUID(),
+    id: crypto.randomUUID() as BookId,
     userId,
     title: data.title,
     authors: data.authors,
@@ -90,9 +91,9 @@ export function toBookResponse(book: Book): BookResponse {
 /**
  * API入力からTagInputへ変換
  */
-export function toTagInput(data: CreateTagInput, userId: string): TagInput {
+export function toTagInput(data: CreateTagInput, userId: UserId): TagInput {
   return {
-    id: crypto.randomUUID(),
+    id: crypto.randomUUID() as TagId,
     userId,
     name: data.name,
     createdAt: new Date().toISOString(),

--- a/app/server/lib/session.test.ts
+++ b/app/server/lib/session.test.ts
@@ -9,16 +9,17 @@ import {
   deleteAllUserSessions,
   regenerateSession,
 } from "./session";
+import type { UserId } from "../../types/domain";
 
 describe("Session helpers", () => {
   it("should create and get a session", async () => {
-    const sessionId = await createSession(env.KV, "user-1");
+    const sessionId = await createSession(env.KV, "user-1" as UserId);
     const userId = await getSession(env.KV, sessionId);
     expect(userId).toBe("user-1");
   });
 
   it("should validate existing session", async () => {
-    const sessionId = await createSession(env.KV, "user-2");
+    const sessionId = await createSession(env.KV, "user-2" as UserId);
     const userId = await validateSession(env.KV, sessionId);
     expect(userId).toBe("user-2");
   });
@@ -28,14 +29,14 @@ describe("Session helpers", () => {
   });
 
   it("should delete a session", async () => {
-    const sessionId = await createSession(env.KV, "user-3");
+    const sessionId = await createSession(env.KV, "user-3" as UserId);
     await deleteSession(env.KV, sessionId);
     const userId = await getSession(env.KV, sessionId);
     expect(userId).toBeNull();
   });
 
   it("should refresh an existing session", async () => {
-    const sessionId = await createSession(env.KV, "user-4", 60);
+    const sessionId = await createSession(env.KV, "user-4" as UserId, 60);
     await refreshSession(env.KV, sessionId, 60);
     const userId = await getSession(env.KV, sessionId);
     expect(userId).toBe("user-4");
@@ -46,8 +47,8 @@ describe("Session helpers", () => {
   });
 
   it("should regenerate session and remove old session", async () => {
-    const oldSessionId = await createSession(env.KV, "user-5");
-    const newSessionId = await regenerateSession(env.KV, oldSessionId, "user-5");
+    const oldSessionId = await createSession(env.KV, "user-5" as UserId);
+    const newSessionId = await regenerateSession(env.KV, oldSessionId, "user-5" as UserId);
 
     expect(newSessionId).not.toBe(oldSessionId);
     expect(await getSession(env.KV, oldSessionId)).toBeNull();
@@ -55,8 +56,8 @@ describe("Session helpers", () => {
   });
 
   it("should delete all user sessions", async () => {
-    const sessionA = await createSession(env.KV, "user-6");
-    const sessionB = await createSession(env.KV, "user-6");
+    const sessionA = await createSession(env.KV, "user-6" as UserId);
+    const sessionB = await createSession(env.KV, "user-6" as UserId);
 
     await deleteAllUserSessions(env.KV, [sessionA, sessionB]);
 

--- a/app/server/lib/session.ts
+++ b/app/server/lib/session.ts
@@ -1,5 +1,6 @@
 import { UnauthorizedError } from "./errors";
 import type { Env } from "../../types/env";
+import type { UserId, SessionId } from "../../types/domain";
 
 type KVNamespace = Env["KV"];
 
@@ -23,10 +24,10 @@ export const SESSION_COOKIE_OPTIONS = {
  */
 export async function createSession(
   kv: KVNamespace,
-  userId: string,
+  userId: UserId,
   ttl: number = SESSION_TTL,
-): Promise<string> {
-  const sessionId = crypto.randomUUID();
+): Promise<SessionId> {
+  const sessionId = crypto.randomUUID() as SessionId;
   const key = `${SESSION_PREFIX}${sessionId}`;
 
   await kv.put(key, userId, {
@@ -39,15 +40,16 @@ export async function createSession(
 /**
  * セッションを取得
  */
-export async function getSession(kv: KVNamespace, sessionId: string): Promise<string | null> {
+export async function getSession(kv: KVNamespace, sessionId: string): Promise<UserId | null> {
   const key = `${SESSION_PREFIX}${sessionId}`;
-  return await kv.get(key);
+  const userId = await kv.get(key);
+  return userId as UserId | null;
 }
 
 /**
  * セッションを検証してユーザーIDを取得（存在しない場合はエラー）
  */
-export async function validateSession(kv: KVNamespace, sessionId: string): Promise<string> {
+export async function validateSession(kv: KVNamespace, sessionId: string): Promise<UserId> {
   const userId = await getSession(kv, sessionId);
 
   if (!userId) {
@@ -100,14 +102,12 @@ export async function deleteAllUserSessions(kv: KVNamespace, sessionIds: string[
 export async function regenerateSession(
   kv: KVNamespace,
   oldSessionId: string | undefined,
-  userId: string,
+  userId: UserId,
   ttl: number = SESSION_TTL,
-): Promise<string> {
-  // 既存のセッションがあれば削除
+): Promise<SessionId> {
   if (oldSessionId) {
     await deleteSession(kv, oldSessionId);
   }
 
-  // 新しいセッションを作成
   return createSession(kv, userId, ttl);
 }

--- a/app/test/helpers.ts
+++ b/app/test/helpers.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../types/env";
+import type { UserId, BookId, TagId, BookStatus, SessionId } from "../types/domain";
 
 type D1Database = Env["DB"];
 type KVNamespace = Env["KV"];
@@ -18,7 +19,7 @@ export async function createTestUser(
   }> = {},
 ) {
   const now = new Date().toISOString();
-  const userId = overrides.id || crypto.randomUUID();
+  const userId = (overrides.id || crypto.randomUUID()) as UserId;
   const user = {
     id: userId,
     username: overrides.username || `test_user_${userId.slice(0, 8)}`,
@@ -57,8 +58,8 @@ export async function createTestUser(
 /**
  * テスト用のセッションを作成
  */
-export async function createTestSession(kv: KVNamespace, userId: string): Promise<string> {
-  const sessionId = crypto.randomUUID();
+export async function createTestSession(kv: KVNamespace, userId: UserId): Promise<SessionId> {
+  const sessionId = crypto.randomUUID() as SessionId;
   await kv.put(`session:${sessionId}`, userId, { expirationTtl: 3600 });
   return sessionId;
 }
@@ -68,18 +69,18 @@ export async function createTestSession(kv: KVNamespace, userId: string): Promis
  */
 export async function createTestBook(
   db: D1Database,
-  userId: string,
+  userId: UserId,
   overrides: Partial<{
     id: string;
     title: string;
     authors: string[];
-    status: "unread" | "reading" | "completed";
+    status: BookStatus;
     pageCount: number;
     currentPage: number;
   }> = {},
 ) {
   const now = new Date().toISOString();
-  const bookId = overrides.id || crypto.randomUUID();
+  const bookId = (overrides.id || crypto.randomUUID()) as BookId;
   const book = {
     id: bookId,
     user_id: userId,
@@ -134,9 +135,9 @@ export async function createTestBook(
 /**
  * テスト用のタグを作成
  */
-export async function createTestTag(db: D1Database, userId: string, name?: string) {
+export async function createTestTag(db: D1Database, userId: UserId, name?: string) {
   const now = new Date().toISOString();
-  const tagId = crypto.randomUUID();
+  const tagId = crypto.randomUUID() as TagId;
   const tag = {
     id: tagId,
     user_id: userId,

--- a/app/types/api.ts
+++ b/app/types/api.ts
@@ -1,7 +1,6 @@
-import type { BookStatus } from "./database";
+import type { BookId, OAuthProvider, BookStatus } from "./domain";
 
-// OAuth関連
-export type OAuthProvider = "github" | "google";
+export type { OAuthProvider } from "./domain";
 
 export interface OAuthUser {
   provider: OAuthProvider;
@@ -113,7 +112,7 @@ export interface PublicProfile {
 }
 
 export interface PublicBook {
-  id: string;
+  id: BookId;
   title: string;
   authors: string[];
   publisher: string | null;

--- a/app/types/database.ts
+++ b/app/types/database.ts
@@ -1,48 +1,50 @@
+import type { UserId, BookId, TagId, SessionId, OAuthProvider, BookStatus, BookSortOrder } from "./domain";
+
+export type { BookStatus, BookSortOrder } from "./domain";
+
 // ユーザー
 export interface User {
-  id: string;
+  id: UserId;
   username: string;
   email: string;
   name: string;
   bio: string | null;
   avatar_url: string | null;
-  provider: "github" | "google";
+  provider: OAuthProvider;
   provider_id: string;
   created_at: string;
   updated_at: string;
 }
 
 export interface UserInput {
-  id: string;
+  id: UserId;
   username: string;
   email: string;
   name: string;
   bio?: string | null;
   avatar_url?: string | null;
-  provider: "github" | "google";
+  provider: OAuthProvider;
   provider_id: string;
   created_at: string;
   updated_at: string;
 }
 
 export interface UserResponse {
-  id: string;
+  id: UserId;
   username: string;
   email: string;
   name: string;
   bio: string | null;
   avatarUrl: string | null;
-  provider: "github" | "google";
+  provider: OAuthProvider;
   createdAt: string;
   updatedAt: string;
 }
 
 // 書籍
-export type BookStatus = "unread" | "reading" | "completed";
-
 export interface Book {
-  id: string;
-  user_id: string;
+  id: BookId;
+  user_id: UserId;
   rakuten_books_id: string | null;
   title: string;
   authors: string; // JSON文字列
@@ -62,8 +64,8 @@ export interface Book {
 }
 
 export interface BookInput {
-  id: string;
-  userId: string;
+  id: BookId;
+  userId: UserId;
   rakutenBooksId?: string | null;
   title: string;
   authors: string[]; // 配列（保存時にJSON化）
@@ -85,12 +87,12 @@ export interface BookInput {
 export interface BookFilter {
   status?: BookStatus;
   search?: string;
-  sortBy?: "title" | "created" | "updated" | "progress";
+  sortBy?: BookSortOrder;
 }
 
 export interface BookResponse {
-  id: string;
-  userId: string;
+  id: BookId;
+  userId: UserId;
   rakutenBooksId: string | null;
   title: string;
   authors: string[];
@@ -111,43 +113,43 @@ export interface BookResponse {
 
 // タグ
 export interface Tag {
-  id: string;
-  user_id: string;
+  id: TagId;
+  user_id: UserId;
   name: string;
   created_at: string;
 }
 
 export interface TagInput {
-  id: string;
-  userId: string;
+  id: TagId;
+  userId: UserId;
   name: string;
   createdAt: string;
 }
 
 export interface TagResponse {
-  id: string;
-  userId: string;
+  id: TagId;
+  userId: UserId;
   name: string;
   createdAt: string;
 }
 
 // 書籍-タグ
 export interface BookTag {
-  book_id: string;
-  tag_id: string;
+  book_id: BookId;
+  tag_id: TagId;
 }
 
 // セッション
 export interface Session {
-  id: string;
-  user_id: string;
+  id: SessionId;
+  user_id: UserId;
   expires_at: string;
   created_at: string;
 }
 
 export interface SessionInput {
-  id: string;
-  userId: string;
+  id: SessionId;
+  userId: UserId;
   expiresAt: string;
   createdAt: string;
 }

--- a/app/types/domain.ts
+++ b/app/types/domain.ts
@@ -1,0 +1,31 @@
+/**
+ * Branded/Nominal type utility
+ * 同じプリミティブ型でも異なるドメイン概念を型レベルで区別するための仕組み
+ */
+declare const brandSymbol: unique symbol;
+export type Brand<T, B extends string> = T & { readonly [brandSymbol]: B };
+
+/**
+ * Branded ID types
+ * string を渡せる場所で誤って別 ID を渡してしまうミスをコンパイル時に検出できる
+ */
+export type UserId = Brand<string, "UserId">;
+export type BookId = Brand<string, "BookId">;
+export type TagId = Brand<string, "TagId">;
+export type SessionId = Brand<string, "SessionId">;
+
+/**
+ * OAuth プロバイダー - 単一の定義元
+ */
+export type OAuthProvider = "github" | "google";
+
+/**
+ * 書籍ステータス - 単一の定義元
+ * unread: 積読, reading: 読書中, completed: 読了
+ */
+export type BookStatus = "unread" | "reading" | "completed";
+
+/**
+ * 書籍ソート順
+ */
+export type BookSortOrder = "title" | "created" | "updated" | "progress";

--- a/app/types/env.ts
+++ b/app/types/env.ts
@@ -1,5 +1,6 @@
 import type { SecureHeadersVariables } from "hono/secure-headers";
 import type { User } from "./database";
+import type { UserId } from "./domain";
 
 export interface Env extends Cloudflare.Env {
   // wrangler.jsonc に定義されていない環境変数
@@ -11,7 +12,7 @@ export interface Env extends Cloudflare.Env {
  * SecureHeadersVariablesを含めてCSP nonceを対応させる
  */
 export interface Variables extends SecureHeadersVariables {
-  userId: string;
+  userId: UserId;
   user: User;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Branded Typesでドメインモデルを表現し、ID やステータスなどの概念を型レベルで区別できるようにしました。

- `app/types/domain.ts` を追加し、`UserId` / `BookId` / `TagId` / `SessionId`、`OAuthProvider`、`BookStatus`、`BookSortOrder` を単一定義元に集約
- DB リポジトリ、セッション、認証、マッパー、API ハンドラー、テストをブランド型に対応
- `OAuthProvider` と `BookStatus` の重複定義を解消

## 確認

- `pnpm typecheck` 成功
- `pnpm lint` エラーなし（既存 warning のみ）

## 補足

- 実行時の挙動は変更していません
- HTTP パラメータや UUID 生成などの外部境界でのみ `as BookId` 等のキャストを行い、アプリ内部では型安全性を担保しています
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-796ce844-1d15-4db2-afb3-7a956b3fe944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-796ce844-1d15-4db2-afb3-7a956b3fe944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

