### PR TITLE
公開プロフィールURLの設計書と設定表示を`/user/:username`にした

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@
 
 ### 公開プロフィール
 
-- `/@:username` - 公開プロフィールページ（読了本 + 読書中の本を表示）
+- `/user/:username` - 公開プロフィールページ（読了本 + 読書中の本を表示）
 
 ### 設定
 
@@ -189,7 +189,7 @@
 
 ### URL 形式
 
-`gidoku.com/@username`
+`gidoku.com/user/username`
 
 ### 表示内容
 

--- a/app/islands/ProfileForm.tsx
+++ b/app/islands/ProfileForm.tsx
@@ -89,7 +89,7 @@ export default function ProfileForm({
           </label>
           <div class="flex rounded-xl shadow-sm ring-1 ring-zinc-200 overflow-hidden">
             <span class="inline-flex items-center px-4 border-r border-zinc-200 bg-zinc-50 text-zinc-500 text-sm font-medium">
-              gidoku.com/@
+              gidoku.com/user/
             </span>
             <input
               type="text"


### PR DESCRIPTION
## 概要

公開プロフィールURLの表記を、実装済みのルートである `/user/:username` に合わせました。

- 設計書内の公開プロフィール画面パスを `/@:username` から `/user/:username` に変更
- 設計書内のURL形式を `gidoku.com/@username` から `gidoku.com/user/username` に変更
- 設定画面のユーザーID入力欄に表示されるURLプレフィックスを `gidoku.com/@` から `gidoku.com/user/` に変更

## 確認

- 差分が `CLAUDE.md` と `app/islands/ProfileForm.tsx` の2ファイルのみであることを確認しました。
- `@username` / `gidoku.com/@` 表記が残っていないことを確認しました。