### PR TITLE
公開プロフィール(user/:username)で本はリンクにしない

### DIFF
--- a/app/islands/ProfileBookTabs.tsx
+++ b/app/islands/ProfileBookTabs.tsx
@@ -106,8 +106,8 @@ export default function ProfileBookTabs({
             {books.length > 0 ? (
               <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-x-6 gap-y-10">
                 {books.map((book) => (
-                  <a href={`/books/${book.id}`} class="group flex flex-col gap-3">
-                    <div class="relative aspect-2/3 w-full bg-zinc-100 rounded-xl shadow-sm group-hover:shadow-md transition-all duration-300 ring-1 ring-black/5 overflow-hidden">
+                  <div class="flex flex-col gap-3">
+                    <div class="relative aspect-2/3 w-full bg-zinc-100 rounded-xl shadow-sm ring-1 ring-black/5 overflow-hidden">
                       <BookCover
                         src={book.thumbnailUrl}
                         alt={book.title}
@@ -117,12 +117,12 @@ export default function ProfileBookTabs({
                     </div>
 
                     <div class="space-y-1">
-                      <h3 class="font-semibold text-zinc-900 text-sm leading-snug line-clamp-2 group-hover:text-blue-600 transition-colors">
+                      <h3 class="font-semibold text-zinc-900 text-sm leading-snug line-clamp-2">
                         {book.title}
                       </h3>
                       <p class="text-xs text-zinc-500 line-clamp-1">{book.authors.join(", ")}</p>
                     </div>
-                  </a>
+                  </div>
                 ))}
               </div>
             ) : (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

公開プロフィール（`/user/:username`）の本一覧から `/books/:id` へのリンクを削除し、静的なカード表示に変更しました。

`/books/:id` は認証必須かつ本人の本のみ閲覧可能なため、公開プロフィールの訪問者が本をクリックしても詳細ページには遷移できません。公開プロフィールの目的は「何を読んでいるか・読んだかを見せる」ことなので、リンクは不要です。

## 確認

- [x] `pnpm run typecheck`
- [x] 公開プロフィールで本カードをクリックしても遷移しないこと
- [x] ホバー時にリンクらしいスタイル（影の強調・青文字）が付かないこと

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f213b3d6-561e-4306-96de-be182bf6e8fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f213b3d6-561e-4306-96de-be182bf6e8fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

