### PR TITLE
公開プロフィールの書籍APIと統計表示を公開範囲に合わせる

### DIFF
--- a/app/components/user/UserStats.tsx
+++ b/app/components/user/UserStats.tsx
@@ -2,27 +2,32 @@ import type { FC } from "hono/jsx";
 
 interface UserStatsProps {
   totalBooks: number;
+  unreadBooks: number;
   readingBooks: number;
   completedBooks: number;
 }
 
-export const UserStats: FC<UserStatsProps> = ({ totalBooks, readingBooks, completedBooks }) => {
+export const UserStats: FC<UserStatsProps> = ({
+  totalBooks,
+  unreadBooks,
+  readingBooks,
+  completedBooks,
+}) => {
+  const items = [
+    { label: "冊", value: totalBooks },
+    { label: "積読中", value: unreadBooks },
+    { label: "読書中", value: readingBooks },
+    { label: "読了", value: completedBooks },
+  ];
+
   return (
-    <div class="flex items-center gap-8 text-zinc-600">
-      <div class="flex items-baseline gap-2">
-        <span class="text-3xl font-bold text-zinc-900">{totalBooks}</span>
-        <span class="text-sm">冊</span>
-      </div>
-      <div class="w-px h-8 bg-zinc-200"></div>
-      <div class="flex items-baseline gap-2">
-        <span class="text-3xl font-bold text-zinc-900">{readingBooks}</span>
-        <span class="text-sm">読書中</span>
-      </div>
-      <div class="w-px h-8 bg-zinc-200"></div>
-      <div class="flex items-baseline gap-2">
-        <span class="text-3xl font-bold text-zinc-900">{completedBooks}</span>
-        <span class="text-sm">読了</span>
-      </div>
+    <div class="grid grid-cols-2 gap-x-8 gap-y-4 text-zinc-600 sm:grid-cols-4">
+      {items.map((item) => (
+        <div key={item.label} class="flex items-baseline gap-2">
+          <span class="text-3xl font-bold text-zinc-900">{item.value}</span>
+          <span class="text-sm">{item.label}</span>
+        </div>
+      ))}
     </div>
   );
 };

--- a/app/routes/user/[username].tsx
+++ b/app/routes/user/[username].tsx
@@ -103,6 +103,7 @@ const ProfilePage: FC<ProfilePageProps> = ({
         <h2 class="text-xl font-bold text-zinc-900 mb-6">本棚</h2>
         <UserStats
           totalBooks={stats.total}
+          unreadBooks={stats.unread}
           readingBooks={stats.reading}
           completedBooks={stats.completed}
         />

--- a/app/server/api/users.test.ts
+++ b/app/server/api/users.test.ts
@@ -121,10 +121,17 @@ describe("Users API Integration", () => {
     expect("provider" in body.data).toBe(false);
   });
 
-  it("should return only completed books for public profile", async () => {
+  it("should return unread, reading, and completed books for public profile", async () => {
     const user = await createTestUser(env.DB);
-    await createTestBook(env.DB, user.id, { status: "completed" });
-    await createTestBook(env.DB, user.id, { status: "reading" });
+    const otherUser = await createTestUser(env.DB, {
+      username: "other_user",
+      email: "other@example.com",
+    });
+
+    await createTestBook(env.DB, user.id, { status: "completed", memo: "private completed memo" });
+    await createTestBook(env.DB, user.id, { status: "reading", memo: "private reading memo" });
+    await createTestBook(env.DB, user.id, { status: "unread", memo: "private unread memo" });
+    await createTestBook(env.DB, otherUser.id, { status: "completed" });
 
     const res = await api.request(`/users/${user.username}/books`, {}, env);
     expect(res.status).toBe(200);
@@ -132,9 +139,13 @@ describe("Users API Integration", () => {
       success: boolean;
       data: Array<{ status: string; memo: string | null }>;
     };
-    expect(body.data).toHaveLength(1);
-    expect(body.data[0].status).toBe("completed");
-    expect(body.data[0].memo).toBeNull();
+    expect(body.data).toHaveLength(3);
+    expect(body.data.map((book) => book.status).toSorted()).toEqual([
+      "completed",
+      "reading",
+      "unread",
+    ]);
+    expect(body.data.every((book) => book.memo === null)).toBe(true);
   });
 
   it("should delete user account", async () => {

--- a/app/server/api/users.test.ts
+++ b/app/server/api/users.test.ts
@@ -131,6 +131,7 @@ describe("Users API Integration", () => {
     await createTestBook(env.DB, user.id, { status: "completed", memo: "private completed memo" });
     await createTestBook(env.DB, user.id, { status: "reading", memo: "private reading memo" });
     await createTestBook(env.DB, user.id, { status: "unread", memo: "private unread memo" });
+    // 別ユーザーの本がレスポンスに混ざらないことを確認する
     await createTestBook(env.DB, otherUser.id, { status: "completed" });
 
     const res = await api.request(`/users/${user.username}/books`, {}, env);

--- a/app/server/api/users.ts
+++ b/app/server/api/users.ts
@@ -87,9 +87,8 @@ app.get("/:username/books", optionalAuthMiddleware, async (c) => {
   const username = c.req.param("username");
   const user = await userRepo.findByUsername(c.env.DB, username);
 
-  // 完了した書籍のみ公開
+  // 公開プロフィールと同じく、積読/読書中/読了の書籍を公開
   const { books } = await bookRepo.findByUserId(c.env.DB, user.id, {
-    status: "completed",
     limit: 50,
     offset: 0,
   });

--- a/app/server/db/repositories/book.test.ts
+++ b/app/server/db/repositories/book.test.ts
@@ -180,11 +180,10 @@ describe("Book Repository", () => {
     it("should return zeros for user with no books", async () => {
       const stats = await bookRepo.getStats(env.DB, userId);
 
-      // D1 returns null for SUM of empty result, so we check for 0 or null
       expect(stats.total).toBe(0);
-      expect(stats.reading ?? 0).toBe(0);
-      expect(stats.completed ?? 0).toBe(0);
-      expect(stats.unread ?? 0).toBe(0);
+      expect(stats.reading).toBe(0);
+      expect(stats.completed).toBe(0);
+      expect(stats.unread).toBe(0);
     });
   });
 

--- a/app/server/db/repositories/book.ts
+++ b/app/server/db/repositories/book.ts
@@ -266,9 +266,9 @@ export async function getStats(db: D1Database, userId: string): Promise<BookStat
         `
         SELECT 
           COUNT(*) as total,
-          SUM(CASE WHEN status = 'reading' THEN 1 ELSE 0 END) as reading,
-          SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
-          SUM(CASE WHEN status = 'unread' THEN 1 ELSE 0 END) as unread
+          COALESCE(SUM(CASE WHEN status = 'reading' THEN 1 ELSE 0 END), 0) as reading,
+          COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0) as completed,
+          COALESCE(SUM(CASE WHEN status = 'unread' THEN 1 ELSE 0 END), 0) as unread
         FROM books 
         WHERE user_id = ?
       `,

--- a/app/test/helpers.ts
+++ b/app/test/helpers.ts
@@ -76,6 +76,7 @@ export async function createTestBook(
     status: "unread" | "reading" | "completed";
     pageCount: number;
     currentPage: number;
+    memo: string | null;
   }> = {},
 ) {
   const now = new Date().toISOString();
@@ -95,7 +96,7 @@ export async function createTestBook(
     rakuten_affiliate_url: null,
     status: overrides.status || "unread",
     current_page: overrides.currentPage || 0,
-    memo: null,
+    memo: overrides.memo ?? null,
     finished_at: null,
     created_at: now,
     updated_at: now,


### PR DESCRIPTION
## 概要

公開プロフィールの公開範囲を、設計書で定義した `unread / reading / completed` に合わせました。

- `/api/users/:username/books` の `completed` 固定フィルタを外し、積読中 / 読書中 / 読了本を返すように変更
- 公開APIでは引き続き `memo` を `null` にして、非公開情報を返さないように維持
- 公開プロフィールの統計表示に `積読中` を追加
- コミットは API 変更と画面統計表示の変更で分けています

## リファクタリング

- 書籍統計の `SUM(...)` を `COALESCE(..., 0)` で正規化し、0冊時も `BookStats` の各値が `0` になるようにしました

## 確認

- `vitest run app/server/api/users.test.ts --reporter verbose`
- `tsc --noEmit`
- `oxlint app/server/api/users.ts app/server/api/users.test.ts app/test/helpers.ts app/components/user/UserStats.tsx app/routes/user/[username].tsx`
- `git diff --check`

## 補足

公開プロフィールの本カードは現在も `/books/:id` にリンクしています。このPRでは公開範囲のAPI/統計表示だけを揃え、公開本詳細ページやカードリンクの扱いは別途検討します。
