### PR TITLE
公開プロフィールの書籍取得をservice層に集約

### DIFF
--- a/app/routes/user/[username].tsx
+++ b/app/routes/user/[username].tsx
@@ -5,19 +5,10 @@ import { PublicProfileLayout } from "../../components/layout/PublicProfileLayout
 import { UserProfile } from "../../components/user/UserProfile";
 import { UserStats } from "../../components/user/UserStats";
 import ProfileBookTabs from "../../islands/ProfileBookTabs";
-import { userRepo, bookRepo } from "../../server/db/repositories";
-import type { User, Book, BookStats, BookStatus } from "../../types/database";
-
-interface BookListItem {
-  id: string;
-  title: string;
-  authors: string[];
-  publisher: string | null;
-  thumbnailUrl: string | null;
-  status: BookStatus;
-  currentPage: number;
-  pageCount: number;
-}
+import { userRepo } from "../../server/db/repositories";
+import { publicProfileService } from "../../server/services";
+import type { PublicProfileBookListItem } from "../../server/services/publicProfile";
+import type { User, BookStats } from "../../types/database";
 
 interface PageProps {
   currentUser: User | null;
@@ -30,21 +21,10 @@ interface NotFoundPageProps extends PageProps {
 interface ProfilePageProps extends PageProps {
   profileUser: User;
   stats: BookStats;
-  readingBooks: BookListItem[];
-  unreadBooks: BookListItem[];
-  completedBooks: BookListItem[];
+  readingBooks: PublicProfileBookListItem[];
+  unreadBooks: PublicProfileBookListItem[];
+  completedBooks: PublicProfileBookListItem[];
 }
-
-const toBookListItem = (book: Book): BookListItem => ({
-  id: book.id,
-  title: book.title,
-  authors: JSON.parse(book.authors) as string[],
-  publisher: book.publisher,
-  thumbnailUrl: book.thumbnail_url,
-  status: book.status,
-  currentPage: book.current_page,
-  pageCount: book.page_count,
-});
 
 const NotFoundPage: FC<NotFoundPageProps> = ({ username, currentUser }) => (
   <PublicProfileLayout user={currentUser} title="ユーザーが見つかりません">
@@ -132,35 +112,16 @@ export default createRoute(async (c) => {
     return c.render(<NotFoundPage username={username} currentUser={currentUser} />);
   }
 
-  const [
-    stats,
-    { books: rawReadingBooks },
-    { books: rawUnreadBooks },
-    { books: rawCompletedBooks },
-  ] = await Promise.all([
-    bookRepo.getStats(c.env.DB, profileUser.id),
-    bookRepo.findByUserId(c.env.DB, profileUser.id, { status: "reading", limit: 12, offset: 0 }),
-    bookRepo.findByUserId(c.env.DB, profileUser.id, {
-      status: "unread",
-      sortBy: "updated",
-      limit: 24,
-      offset: 0,
-    }),
-    bookRepo.findByUserId(c.env.DB, profileUser.id, {
-      status: "completed",
-      sortBy: "updated",
-      limit: 24,
-      offset: 0,
-    }),
-  ]);
+  const { stats, readingBooks, unreadBooks, completedBooks } =
+    await publicProfileService.getPublicProfileBooks(c.env.DB, profileUser.id);
 
   return c.render(
     <ProfilePage
       profileUser={profileUser}
       stats={stats}
-      readingBooks={rawReadingBooks.map(toBookListItem)}
-      unreadBooks={rawUnreadBooks.map(toBookListItem)}
-      completedBooks={rawCompletedBooks.map(toBookListItem)}
+      readingBooks={readingBooks}
+      unreadBooks={unreadBooks}
+      completedBooks={completedBooks}
       currentUser={currentUser}
     />,
   );

--- a/app/server/api/users.ts
+++ b/app/server/api/users.ts
@@ -1,14 +1,15 @@
 import { Hono } from "hono";
 import type { HonoContext } from "../../types/env";
-import { userRepo, bookRepo } from "../db/repositories";
+import { userRepo } from "../db/repositories";
 import { authMiddleware, optionalAuthMiddleware } from "../lib/auth";
 import { validator, getValidated } from "../lib/validator";
 import { updateUserSchema, usernameSchema } from "./schemas";
 import type { UpdateUserInput } from "./schemas/user";
 import { isReservedUsername } from "./schemas/user";
-import { toUserResponse, toBookResponse } from "../lib/mapper";
+import { toUserResponse } from "../lib/mapper";
 import { successResponse } from "../lib/response";
 import { invalidateUserCache } from "../lib/auth";
+import { publicProfileService } from "../services";
 
 const app = new Hono<HonoContext>();
 
@@ -87,20 +88,9 @@ app.get("/:username/books", optionalAuthMiddleware, async (c) => {
   const username = c.req.param("username");
   const user = await userRepo.findByUsername(c.env.DB, username);
 
-  // 公開プロフィールと同じく、積読/読書中/読了の書籍を公開
-  const { books } = await bookRepo.findByUserId(c.env.DB, user.id, {
-    limit: 50,
-    offset: 0,
-  });
+  const books = await publicProfileService.getPublicBookResponses(c.env.DB, user.id);
 
-  return successResponse(
-    c,
-    books.map((book) => {
-      const response = toBookResponse(book);
-      response.memo = null;
-      return response;
-    }),
-  );
+  return successResponse(c, books);
 });
 
 /**

--- a/app/server/services/index.ts
+++ b/app/server/services/index.ts
@@ -1,2 +1,3 @@
 export * as oauthService from "./oauth";
+export * as publicProfileService from "./publicProfile";
 export * as rakutenService from "./rakuten";

--- a/app/server/services/publicProfile.test.ts
+++ b/app/server/services/publicProfile.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { cleanupDatabase, createTestBook, createTestUser } from "../../test/helpers";
+import * as publicProfileService from "./publicProfile";
+
+describe("Public Profile Service", () => {
+  beforeEach(async () => {
+    await cleanupDatabase(env.DB);
+  });
+
+  it("should return public profile books grouped by status", async () => {
+    const user = await createTestUser(env.DB);
+    const otherUser = await createTestUser(env.DB, {
+      username: "other_user",
+      email: "other@example.com",
+    });
+
+    await createTestBook(env.DB, user.id, {
+      title: "Reading Book",
+      authors: ["Reading Author"],
+      status: "reading",
+    });
+    await createTestBook(env.DB, user.id, {
+      title: "Unread Book",
+      authors: ["Unread Author"],
+      status: "unread",
+    });
+    await createTestBook(env.DB, user.id, {
+      title: "Completed Book",
+      authors: ["Completed Author"],
+      status: "completed",
+    });
+    await createTestBook(env.DB, otherUser.id, {
+      title: "Other User Book",
+      status: "completed",
+    });
+
+    const result = await publicProfileService.getPublicProfileBooks(env.DB, user.id);
+
+    expect(result.stats).toMatchObject({
+      total: 3,
+      unread: 1,
+      reading: 1,
+      completed: 1,
+    });
+    expect(result.readingBooks).toHaveLength(1);
+    expect(result.readingBooks[0]).toMatchObject({
+      title: "Reading Book",
+      authors: ["Reading Author"],
+      status: "reading",
+    });
+    expect(result.unreadBooks).toHaveLength(1);
+    expect(result.unreadBooks[0].title).toBe("Unread Book");
+    expect(result.completedBooks).toHaveLength(1);
+    expect(result.completedBooks[0].title).toBe("Completed Book");
+  });
+
+  it("should hide memo from public book responses", async () => {
+    const user = await createTestUser(env.DB);
+
+    await createTestBook(env.DB, user.id, {
+      status: "unread",
+      memo: "private memo",
+    });
+
+    const books = await publicProfileService.getPublicBookResponses(env.DB, user.id);
+
+    expect(books).toHaveLength(1);
+    expect(books[0].status).toBe("unread");
+    expect(books[0].memo).toBeNull();
+  });
+});

--- a/app/server/services/publicProfile.ts
+++ b/app/server/services/publicProfile.ts
@@ -1,0 +1,118 @@
+import type { Env } from "../../types/env";
+import type { Book, BookResponse, BookStats, BookStatus } from "../../types/database";
+import { bookRepo } from "../db/repositories";
+import { toBookResponse } from "../lib/mapper";
+
+type D1Database = Env["DB"];
+
+export const PUBLIC_PROFILE_BOOK_STATUSES = [
+  "unread",
+  "reading",
+  "completed",
+] as const satisfies readonly BookStatus[];
+
+export type PublicProfileBookStatus = (typeof PUBLIC_PROFILE_BOOK_STATUSES)[number];
+
+interface PublicProfileBookListLimits {
+  reading: number;
+  unread: number;
+  completed: number;
+}
+
+const publicProfileBookListLimits = {
+  reading: 12,
+  unread: 24,
+  completed: 24,
+} satisfies PublicProfileBookListLimits;
+
+export interface PublicProfileBookListItem {
+  id: string;
+  title: string;
+  authors: string[];
+  publisher: string | null;
+  thumbnailUrl: string | null;
+  status: BookStatus;
+  currentPage: number;
+  pageCount: number;
+}
+
+export interface PublicProfileBooks {
+  stats: BookStats;
+  readingBooks: PublicProfileBookListItem[];
+  unreadBooks: PublicProfileBookListItem[];
+  completedBooks: PublicProfileBookListItem[];
+}
+
+function isPublicProfileBookStatus(status: BookStatus): status is PublicProfileBookStatus {
+  return PUBLIC_PROFILE_BOOK_STATUSES.includes(status as PublicProfileBookStatus);
+}
+
+function toPublicProfileBookListItem(book: Book): PublicProfileBookListItem {
+  return {
+    id: book.id,
+    title: book.title,
+    authors: JSON.parse(book.authors) as string[],
+    publisher: book.publisher,
+    thumbnailUrl: book.thumbnail_url,
+    status: book.status,
+    currentPage: book.current_page,
+    pageCount: book.page_count,
+  };
+}
+
+export function toPublicBookResponse(book: Book): BookResponse {
+  return {
+    ...toBookResponse(book),
+    memo: null,
+  };
+}
+
+export async function getPublicProfileBooks(
+  db: D1Database,
+  userId: string,
+): Promise<PublicProfileBooks> {
+  const [
+    stats,
+    { books: rawReadingBooks },
+    { books: rawUnreadBooks },
+    { books: rawCompletedBooks },
+  ] = await Promise.all([
+    bookRepo.getStats(db, userId),
+    bookRepo.findByUserId(db, userId, {
+      status: "reading",
+      limit: publicProfileBookListLimits.reading,
+      offset: 0,
+    }),
+    bookRepo.findByUserId(db, userId, {
+      status: "unread",
+      sortBy: "updated",
+      limit: publicProfileBookListLimits.unread,
+      offset: 0,
+    }),
+    bookRepo.findByUserId(db, userId, {
+      status: "completed",
+      sortBy: "updated",
+      limit: publicProfileBookListLimits.completed,
+      offset: 0,
+    }),
+  ]);
+
+  return {
+    stats,
+    readingBooks: rawReadingBooks.map(toPublicProfileBookListItem),
+    unreadBooks: rawUnreadBooks.map(toPublicProfileBookListItem),
+    completedBooks: rawCompletedBooks.map(toPublicProfileBookListItem),
+  };
+}
+
+export async function getPublicBookResponses(
+  db: D1Database,
+  userId: string,
+): Promise<BookResponse[]> {
+  const { books } = await bookRepo.findByUserId(db, userId, {
+    limit: 50,
+    offset: 0,
+  });
+
+  return books.filter((book) => isPublicProfileBookStatus(book.status)).map(toPublicBookResponse);
+}


### PR DESCRIPTION
## 概要

公開プロフィールの書籍取得ロジックを service 層に集約しました。

- `publicProfileService` を追加
- SSR の `/user/:username` と `/api/users/:username/books` が同じ公開プロフィール用ロジックを使うように変更
- 公開用の書籍レスポンスでは `memo` を返さない処理を service 側に移動
- service のテストを追加

## 確認

- `tsc --noEmit`
- `oxlint app/server/services/publicProfile.ts app/server/services/publicProfile.test.ts app/server/services/index.ts app/server/api/users.ts app/routes/user/[username].tsx`
- `vitest run app/server/services/publicProfile.test.ts app/server/api/users.test.ts --reporter verbose`
- `git diff --check`