### PR TITLE
DTOの土台と書籍検索フローを整備

### DIFF
--- a/app/components/book/BookSearchResult.tsx
+++ b/app/components/book/BookSearchResult.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "hono/jsx";
-import type { BookSearchResult as SearchResult } from "../../types/api";
+import type { BookSearchResultDto as SearchResult } from "../../types/dto";
 import { Card, CardBody } from "../ui/Card";
 import { Button } from "../ui/Button";
 import { BookCover } from "./BookCover";

--- a/app/islands/BookSearchForm.tsx
+++ b/app/islands/BookSearchForm.tsx
@@ -1,34 +1,14 @@
 import { useState } from "hono/jsx";
-
-interface SearchResult {
-  rakutenBooksId: string;
-  title: string;
-  authors: string[];
-  publisher: string;
-  publishedDate: string;
-  isbn: string;
-  pageCount: number;
-  description: string;
-  thumbnailUrl: string;
-  rakutenAffiliateUrl: string;
-}
-
-interface ApiResponse<T = unknown> {
-  success: boolean;
-  data?: T;
-  error?: { message: string };
-}
-
-interface SearchResponse {
-  results: SearchResult[];
-  hits: number;
-  pageCount: number;
-  currentPage: number;
-}
+import type {
+  ApiResponseDto,
+  BookDto,
+  BookSearchResultDto,
+  SearchBooksResponseDto,
+} from "../types/dto";
 
 export default function BookSearchForm() {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SearchResult[]>([]);
+  const [results, setResults] = useState<BookSearchResultDto[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
@@ -44,9 +24,9 @@ export default function BookSearchForm() {
 
     try {
       const res = await fetch(`/api/search/books?query=${encodeURIComponent(query)}&page=1`);
-      const data = (await res.json()) as ApiResponse<SearchResponse>;
+      const data = (await res.json()) as ApiResponseDto<SearchBooksResponseDto>;
 
-      if (data.success && data.data) {
+      if (data.success) {
         setResults(data.data.results);
         setHasMore(data.data.currentPage < data.data.pageCount);
         setCurrentPage(data.data.currentPage);
@@ -70,12 +50,12 @@ export default function BookSearchForm() {
       const res = await fetch(
         `/api/search/books?query=${encodeURIComponent(query)}&page=${nextPage}`,
       );
-      const data = (await res.json()) as ApiResponse<SearchResponse>;
+      const data = (await res.json()) as ApiResponseDto<SearchBooksResponseDto>;
 
-      if (data.success && data.data) {
-        setResults((prev) => [...prev, ...data.data!.results]);
+      if (data.success) {
+        setResults((prev) => [...prev, ...data.data.results]);
         setCurrentPage(nextPage);
-        setHasMore(nextPage < data.data!.pageCount);
+        setHasMore(nextPage < data.data.pageCount);
       } else {
         setError(data.error?.message || "読み込みに失敗しました");
       }
@@ -86,7 +66,7 @@ export default function BookSearchForm() {
     }
   };
 
-  const handleSelect = async (book: SearchResult) => {
+  const handleSelect = async (book: BookSearchResultDto) => {
     try {
       const res = await fetch("/api/books", {
         method: "POST",
@@ -106,9 +86,9 @@ export default function BookSearchForm() {
         }),
       });
 
-      const data = (await res.json()) as ApiResponse<{ id: string }>;
+      const data = (await res.json()) as ApiResponseDto<BookDto>;
 
-      if (data.success && data.data) {
+      if (data.success) {
         window.location.href = `/books/${data.data.id}`;
       } else {
         alert(data.error?.message || "登録に失敗しました");

--- a/app/types/dto/book.ts
+++ b/app/types/dto/book.ts
@@ -1,0 +1,69 @@
+import type { BookStatus } from "../database";
+
+export interface BookDto {
+  id: string;
+  userId: string;
+  rakutenBooksId: string | null;
+  title: string;
+  authors: string[];
+  publisher: string | null;
+  publishedDate: string | null;
+  isbn: string | null;
+  pageCount: number;
+  description: string | null;
+  thumbnailUrl: string | null;
+  rakutenAffiliateUrl: string | null;
+  status: BookStatus;
+  currentPage: number;
+  memo: string | null;
+  finishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BookDetailDto extends BookDto {
+  tags: string[];
+}
+
+export interface CreateBookRequestDto {
+  rakutenBooksId?: string;
+  title: string;
+  authors: string[];
+  publisher?: string;
+  publishedDate?: string;
+  isbn?: string;
+  pageCount?: number;
+  description?: string;
+  thumbnailUrl?: string;
+  rakutenAffiliateUrl?: string;
+  status?: BookStatus;
+  currentPage?: number;
+  memo?: string;
+  tags?: string[];
+}
+
+export interface UpdateBookRequestDto {
+  title?: string;
+  authors?: string[];
+  publisher?: string;
+  publishedDate?: string;
+  isbn?: string;
+  pageCount?: number;
+  description?: string;
+  thumbnailUrl?: string;
+  status?: BookStatus;
+  currentPage?: number;
+  memo?: string;
+  finishedAt?: string;
+}
+
+export interface UpdateBookProgressRequestDto {
+  currentPage: number;
+}
+
+export interface BookStatsDto {
+  total: number;
+  reading: number;
+  completed: number;
+  unread: number;
+}

--- a/app/types/dto/common.ts
+++ b/app/types/dto/common.ts
@@ -1,0 +1,27 @@
+export interface ApiErrorDto {
+  message: string;
+  code?: string;
+  details?: unknown;
+}
+
+export type ApiResponseDto<T = unknown> =
+  | {
+      success: true;
+      data: T;
+    }
+  | {
+      success: false;
+      error: ApiErrorDto;
+    };
+
+export interface PaginatedDto<T> {
+  items: T[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+export interface DeletedResponseDto {
+  deleted: boolean;
+}

--- a/app/types/dto/index.ts
+++ b/app/types/dto/index.ts
@@ -1,0 +1,3 @@
+export type * from "./book";
+export type * from "./common";
+export type * from "./search";

--- a/app/types/dto/search.ts
+++ b/app/types/dto/search.ts
@@ -1,0 +1,19 @@
+export interface BookSearchResultDto {
+  rakutenBooksId: string;
+  title: string;
+  authors: string[];
+  publisher: string;
+  publishedDate: string;
+  isbn: string;
+  pageCount: number;
+  description: string;
+  thumbnailUrl: string;
+  rakutenAffiliateUrl: string;
+}
+
+export interface SearchBooksResponseDto {
+  results: BookSearchResultDto[];
+  hits: number;
+  pageCount: number;
+  currentPage: number;
+}


### PR DESCRIPTION
## 概要

- API 通信用 DTO の置き場として `app/types/dto` を追加しました。
- 共通レスポンス、Books、Search の DTO を定義しました。
- 書籍検索フォームと検索結果コンポーネントのローカル型を共有 DTO 参照へ置き換えました。

## 確認

- `tsc --noEmit`
- `vitest run app/server/api/books.test.ts app/server/api/tags.test.ts app/server/api/users.test.ts app/server/api/auth.test.ts app/server/api/search.test.ts app/server/services/rakuten.test.ts`

## 補足

- 後続 PR の土台になるため、この PR では DB 型や server mapper の大きな移動はしていません。