### PR TITLE
APIレスポンス読み取りを共通化

### DIFF
--- a/app/islands/BookSearchForm.tsx
+++ b/app/islands/BookSearchForm.tsx
@@ -1,10 +1,10 @@
 import { useState } from "hono/jsx";
 import type {
-  ApiResponseDto,
   BookDto,
   BookSearchResultDto,
   SearchBooksResponseDto,
 } from "../types/dto";
+import { readApiResponse } from "../lib/api-client";
 
 export default function BookSearchForm() {
   const [query, setQuery] = useState("");
@@ -24,7 +24,7 @@ export default function BookSearchForm() {
 
     try {
       const res = await fetch(`/api/search/books?query=${encodeURIComponent(query)}&page=1`);
-      const data = (await res.json()) as ApiResponseDto<SearchBooksResponseDto>;
+      const data = await readApiResponse<SearchBooksResponseDto>(res);
 
       if (data.success) {
         setResults(data.data.results);
@@ -50,7 +50,7 @@ export default function BookSearchForm() {
       const res = await fetch(
         `/api/search/books?query=${encodeURIComponent(query)}&page=${nextPage}`,
       );
-      const data = (await res.json()) as ApiResponseDto<SearchBooksResponseDto>;
+      const data = await readApiResponse<SearchBooksResponseDto>(res);
 
       if (data.success) {
         setResults((prev) => [...prev, ...data.data.results]);
@@ -86,7 +86,7 @@ export default function BookSearchForm() {
         }),
       });
 
-      const data = (await res.json()) as ApiResponseDto<BookDto>;
+      const data = await readApiResponse<BookDto>(res);
 
       if (data.success) {
         window.location.href = `/books/${data.data.id}`;

--- a/app/islands/BookSearchForm.tsx
+++ b/app/islands/BookSearchForm.tsx
@@ -1,9 +1,5 @@
 import { useState } from "hono/jsx";
-import type {
-  BookDto,
-  BookSearchResultDto,
-  SearchBooksResponseDto,
-} from "../types/dto";
+import type { BookDto, BookSearchResultDto, SearchBooksResponseDto } from "../types/dto";
 import { readApiResponse } from "../lib/api-client";
 
 export default function BookSearchForm() {

--- a/app/islands/MemoEditor.tsx
+++ b/app/islands/MemoEditor.tsx
@@ -1,13 +1,10 @@
 import { useState } from "hono/jsx";
+import { getApiErrorMessage, readApiResponse } from "../lib/api-client";
+import type { BookDto } from "../types/dto";
 
 interface MemoEditorProps {
   bookId: string;
   initialMemo: string;
-}
-
-interface ApiResponse {
-  success: boolean;
-  error?: { message: string };
 }
 
 export default function MemoEditor({ bookId, initialMemo }: MemoEditorProps) {
@@ -32,8 +29,8 @@ export default function MemoEditor({ bookId, initialMemo }: MemoEditorProps) {
         setSaved(true);
         setTimeout(() => setSaved(false), 2000);
       } else {
-        const data = (await res.json()) as ApiResponse;
-        alert(data.error?.message || "保存に失敗しました");
+        const data = await readApiResponse<BookDto>(res);
+        alert(getApiErrorMessage(data, "保存に失敗しました"));
       }
     } catch {
       alert("保存中にエラーが発生しました");

--- a/app/islands/ProfileForm.tsx
+++ b/app/islands/ProfileForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from "hono/jsx";
+import { getApiErrorMessage, readApiResponse } from "../lib/api-client";
 
 interface ProfileFormProps {
   avatarUrl: string | null;
@@ -6,12 +7,6 @@ interface ProfileFormProps {
   initialUsername: string;
   initialName: string;
   initialBio: string;
-}
-
-interface ApiResponse {
-  success: boolean;
-  data?: { username: string; name: string; bio: string | null };
-  error?: { message: string };
 }
 
 export default function ProfileForm({
@@ -45,13 +40,17 @@ export default function ProfileForm({
         body: JSON.stringify(body),
       });
 
-      const data = (await res.json()) as ApiResponse;
+      const data = await readApiResponse<{
+        username: string;
+        name: string;
+        bio: string | null;
+      }>(res);
 
       if (res.ok) {
         setSaved(true);
         setTimeout(() => setSaved(false), 2000);
       } else {
-        alert(data.error?.message || "保存に失敗しました");
+        alert(getApiErrorMessage(data, "保存に失敗しました"));
       }
     } catch {
       alert("通信エラーが発生しました");

--- a/app/islands/ProgressSlider.tsx
+++ b/app/islands/ProgressSlider.tsx
@@ -1,14 +1,11 @@
 import { useState } from "hono/jsx";
+import { getApiErrorMessage, readApiResponse } from "../lib/api-client";
+import type { BookDto } from "../types/dto";
 
 interface ProgressSliderProps {
   bookId: string;
   initialPage: number;
   totalPages: number;
-}
-
-interface ApiResponse {
-  success: boolean;
-  error?: { message: string };
 }
 
 export default function ProgressSlider({ bookId, initialPage, totalPages }: ProgressSliderProps) {
@@ -35,8 +32,8 @@ export default function ProgressSlider({ bookId, initialPage, totalPages }: Prog
         setSaved(true);
         setTimeout(() => setSaved(false), 2000);
       } else {
-        const data = (await res.json()) as ApiResponse;
-        alert(data.error?.message || "更新に失敗しました");
+        const data = await readApiResponse<BookDto>(res);
+        alert(getApiErrorMessage(data, "更新に失敗しました"));
       }
     } catch {
       alert("更新中にエラーが発生しました");

--- a/app/islands/StatusToggle.tsx
+++ b/app/islands/StatusToggle.tsx
@@ -1,15 +1,12 @@
 import { useState } from "hono/jsx";
+import { getApiErrorMessage, readApiResponse } from "../lib/api-client";
+import type { BookDto } from "../types/dto";
 
 type BookStatus = "unread" | "reading" | "completed";
 
 interface StatusToggleProps {
   bookId: string;
   currentStatus: BookStatus;
-}
-
-interface ApiResponse {
-  success: boolean;
-  error?: { message: string };
 }
 
 const statusOptions: { value: BookStatus; label: string }[] = [
@@ -37,8 +34,8 @@ export default function StatusToggle({ bookId, currentStatus }: StatusToggleProp
       if (res.ok) {
         setStatus(newStatus);
       } else {
-        const data = (await res.json()) as ApiResponse;
-        alert(data.error?.message || "更新に失敗しました");
+        const data = await readApiResponse<BookDto>(res);
+        alert(getApiErrorMessage(data, "更新に失敗しました"));
       }
     } catch {
       alert("更新中にエラーが発生しました");

--- a/app/islands/TagInput.tsx
+++ b/app/islands/TagInput.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "hono/jsx";
+import { getApiErrorMessage, readApiResponse } from "../lib/api-client";
 
 interface Tag {
   id: string;
@@ -10,12 +11,6 @@ interface TagInputProps {
   initialTags?: Tag[];
 }
 
-interface ApiResponse<T = unknown> {
-  success: boolean;
-  data?: T;
-  error?: { message: string };
-}
-
 export default function TagInput({ bookId, initialTags = [] }: TagInputProps) {
   const [tags, setTags] = useState<Tag[]>(initialTags);
   const [allTags, setAllTags] = useState<Tag[]>([]);
@@ -25,11 +20,10 @@ export default function TagInput({ bookId, initialTags = [] }: TagInputProps) {
   useEffect(() => {
     // ユーザーのタグ一覧を取得
     fetch("/api/tags")
-      .then((res) => res.json())
-      .then((json: unknown) => {
-        const data = json as ApiResponse<Tag[]>;
+      .then((res) => readApiResponse<Tag[]>(res))
+      .then((data) => {
         if (data.success) {
-          setAllTags(data.data || []);
+          setAllTags(data.data);
         }
       })
       .catch(() => {});
@@ -58,8 +52,8 @@ export default function TagInput({ bookId, initialTags = [] }: TagInputProps) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ name }),
         });
-        const createData = (await createRes.json()) as ApiResponse<Tag>;
-        if (createData.success && createData.data) {
+        const createData = await readApiResponse<Tag>(createRes);
+        if (createData.success) {
           tag = createData.data;
           setAllTags([...allTags, tag]);
         } else {
@@ -79,8 +73,8 @@ export default function TagInput({ bookId, initialTags = [] }: TagInputProps) {
         setTags([...tags, tag]);
         setInput("");
       } else {
-        const data = (await res.json()) as ApiResponse;
-        alert(data.error?.message || "タグの追加に失敗しました");
+        const data = await readApiResponse(res);
+        alert(getApiErrorMessage(data, "タグの追加に失敗しました"));
       }
     } catch {
       alert("タグの追加中にエラーが発生しました");
@@ -100,8 +94,8 @@ export default function TagInput({ bookId, initialTags = [] }: TagInputProps) {
       if (res.ok) {
         setTags(tags.filter((t) => t.id !== tagId));
       } else {
-        const data = (await res.json()) as ApiResponse;
-        alert(data.error?.message || "タグの削除に失敗しました");
+        const data = await readApiResponse(res);
+        alert(getApiErrorMessage(data, "タグの削除に失敗しました"));
       }
     } catch {
       alert("タグの削除中にエラーが発生しました");

--- a/app/lib/api-client.ts
+++ b/app/lib/api-client.ts
@@ -1,14 +1,9 @@
 import type { ApiResponseDto } from "../types/dto";
 
-export async function readApiResponse<T>(
-  response: Response
-): Promise<ApiResponseDto<T>> {
+export async function readApiResponse<T>(response: Response): Promise<ApiResponseDto<T>> {
   return response.json() as Promise<ApiResponseDto<T>>;
 }
 
-export function getApiErrorMessage(
-  response: ApiResponseDto<unknown>,
-  fallback: string
-): string {
+export function getApiErrorMessage(response: ApiResponseDto<unknown>, fallback: string): string {
   return response.success ? fallback : response.error.message || fallback;
 }

--- a/app/lib/api-client.ts
+++ b/app/lib/api-client.ts
@@ -1,0 +1,14 @@
+import type { ApiResponseDto } from "../types/dto";
+
+export async function readApiResponse<T>(
+  response: Response
+): Promise<ApiResponseDto<T>> {
+  return response.json() as Promise<ApiResponseDto<T>>;
+}
+
+export function getApiErrorMessage(
+  response: ApiResponseDto<unknown>,
+  fallback: string
+): string {
+  return response.success ? fallback : response.error.message || fallback;
+}


### PR DESCRIPTION
## 概要

- `readApiResponse` を追加して、`res.json() as ...` を API client helper に集約しました。
- 失敗時のメッセージ取得を `getApiErrorMessage` に寄せました。
- 書籍検索、進捗、ステータス、メモ、プロフィール、タグ入力の API 読み取りを helper 経由にしました。

## 確認

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run app/server/api/books.test.ts app/server/api/tags.test.ts app/server/api/users.test.ts app/server/api/auth.test.ts app/server/api/search.test.ts app/server/services/rakuten.test.ts`

## 補足

- runtime validation はまだ入れていません。今回は JSON 境界の型アサーションを 1 箇所に集める変更です。