### PR TITLE
Books APIをDTOへ寄せる

### DIFF
--- a/app/server/api/books.test.ts
+++ b/app/server/api/books.test.ts
@@ -3,7 +3,7 @@ import { env } from "cloudflare:test";
 import api from "./index";
 import { createTestUser, createTestSession, createTestBook } from "../../test/helpers";
 import type { SuccessResponse, PaginatedResponse } from "../lib/response";
-import type { BookResponse } from "../../types/database";
+import type { BookDto, BookStatsDto } from "../../types/dto";
 
 describe("Books API Integration", () => {
   let userId: string;
@@ -49,7 +49,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookDto>>;
       expect(body.success).toBe(true);
       expect(body.data.items).toEqual([]);
       expect(body.data.total).toBe(0);
@@ -68,7 +68,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookDto>>;
       expect(body.data.items).toHaveLength(2);
       expect(body.data.total).toBe(2);
     });
@@ -88,7 +88,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookDto>>;
       expect(body.data.items).toHaveLength(1);
       expect(body.data.items[0].status).toBe("reading");
     });
@@ -106,7 +106,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookDto>>;
       expect(body.data.items).toHaveLength(1);
       expect(body.data.items[0].title).toBe("JavaScript Guide");
     });
@@ -124,7 +124,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookDto>>;
       expect(body.data.items[0].title).toBe("Alpha Book");
     });
 
@@ -142,7 +142,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookResponse>>;
+      const body = (await res.json()) as SuccessResponse<PaginatedResponse<BookDto>>;
       expect(body.data.items).toHaveLength(1);
       expect(body.data.total).toBe(3);
       expect(body.data.limit).toBe(1);
@@ -171,7 +171,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(201);
-      const body = (await res.json()) as SuccessResponse<BookResponse>;
+      const body = (await res.json()) as SuccessResponse<BookDto>;
       expect(body.success).toBe(true);
       expect(body.data.title).toBe("New Test Book");
     });
@@ -199,7 +199,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<BookResponse>;
+      const body = (await res.json()) as SuccessResponse<BookDto>;
       expect(body.data.title).toBe("New Title");
       expect(body.data.status).toBe("reading");
       expect(body.data.currentPage).toBe(10);
@@ -219,7 +219,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<BookResponse>;
+      const body = (await res.json()) as SuccessResponse<BookDto>;
       expect(body.data.title).toBe("My Book");
     });
 
@@ -261,7 +261,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<BookResponse>;
+      const body = (await res.json()) as SuccessResponse<BookDto>;
       expect(body.data.currentPage).toBe(150);
       expect(body.data.status).toBe("reading");
     });
@@ -287,7 +287,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<BookResponse>;
+      const body = (await res.json()) as SuccessResponse<BookDto>;
       expect(body.data.status).toBe("completed");
       expect(body.data.finishedAt).toBeTruthy();
     });
@@ -328,12 +328,7 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<{
-        total: number;
-        reading: number;
-        completed: number;
-        unread: number;
-      }>;
+      const body = (await res.json()) as SuccessResponse<BookStatsDto>;
       expect(body.data.total).toBe(4);
       expect(body.data.reading).toBe(2);
       expect(body.data.completed).toBe(1);

--- a/app/server/api/books.ts
+++ b/app/server/api/books.ts
@@ -16,7 +16,7 @@ import type {
   ProgressInput,
   BookFilterInput,
 } from "./schemas/book";
-import { toBookInput, toBookUpdateInput, toBookResponse } from "../lib/mapper";
+import { toBookDto, toBookInput, toBookUpdateInput } from "../lib/mapper";
 import { bookDomain } from "../domain";
 import { successResponse, paginatedResponse } from "../lib/response";
 import { ValidationError } from "../lib/errors";
@@ -42,7 +42,7 @@ app.get("/", validator("query", bookFilterSchema), async (c) => {
     offset: filter.offset ?? 0,
   });
 
-  const items = books.map(toBookResponse);
+  const items = books.map(toBookDto);
   return paginatedResponse(c, items, total, filter.limit ?? 20, filter.offset ?? 0);
 });
 
@@ -73,7 +73,7 @@ app.get("/:id", validator("param", bookIdSchema), async (c) => {
   const tags = await bookTagRepo.findTagsByBookId(c.env.DB, id);
 
   return successResponse(c, {
-    ...toBookResponse(book),
+    ...toBookDto(book),
     tags,
   });
 });
@@ -89,7 +89,7 @@ app.post("/", validator("json", createBookSchema), async (c) => {
   const bookInput = toBookInput(data, userId);
   const book = await bookRepo.create(c.env.DB, bookInput);
 
-  return successResponse(c, toBookResponse(book), 201);
+  return successResponse(c, toBookDto(book), 201);
 });
 
 /**
@@ -108,7 +108,7 @@ app.put(
     const updateData = toBookUpdateInput(data);
     const book = await bookRepo.update(c.env.DB, id, userId, updateData);
 
-    return successResponse(c, toBookResponse(book));
+    return successResponse(c, toBookDto(book));
   },
 );
 
@@ -148,7 +148,7 @@ app.patch(
       updatedAt: new Date().toISOString(),
     });
 
-    return successResponse(c, toBookResponse(book));
+    return successResponse(c, toBookDto(book));
   },
 );
 

--- a/app/server/api/users.ts
+++ b/app/server/api/users.ts
@@ -6,7 +6,7 @@ import { validator, getValidated } from "../lib/validator";
 import { updateUserSchema, usernameSchema } from "./schemas";
 import type { UpdateUserInput } from "./schemas/user";
 import { isReservedUsername } from "./schemas/user";
-import { toUserResponse, toBookResponse } from "../lib/mapper";
+import { toBookDto, toUserResponse } from "../lib/mapper";
 import { successResponse } from "../lib/response";
 import { invalidateUserCache } from "../lib/auth";
 
@@ -97,7 +97,7 @@ app.get("/:username/books", optionalAuthMiddleware, async (c) => {
   return successResponse(
     c,
     books.map((book) => {
-      const response = toBookResponse(book);
+      const response = toBookDto(book);
       response.memo = null;
       return response;
     }),

--- a/app/server/lib/mapper.ts
+++ b/app/server/lib/mapper.ts
@@ -1,13 +1,13 @@
 import type {
   Book,
   BookInput,
-  BookResponse,
   Tag,
   TagInput,
   TagResponse,
   User,
   UserResponse,
 } from "../../types/database";
+import type { BookDto } from "../../types/dto";
 import type { CreateBookInput, UpdateBookInput } from "../api/schemas/book";
 import type { CreateTagInput } from "../api/schemas/tag";
 import { removeUndefined } from "./utils";
@@ -64,7 +64,7 @@ export function toBookUpdateInput(data: UpdateBookInput): Partial<BookInput> {
 /**
  * DB形式のBookをAPI形式に変換
  */
-export function toBookResponse(book: Book): BookResponse {
+export function toBookDto(book: Book): BookDto {
   return {
     id: book.id,
     userId: book.user_id,

--- a/app/server/lib/response.ts
+++ b/app/server/lib/response.ts
@@ -1,41 +1,29 @@
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { ApiResponseDto, PaginatedDto } from "../../types/dto";
 
 /**
  * 成功レスポンスの型
  */
-export interface SuccessResponse<T = unknown> {
-  success: true;
-  data: T;
-}
+export type SuccessResponse<T = unknown> = Extract<
+  ApiResponseDto<T>,
+  { success: true }
+>;
 
 /**
  * エラーレスポンスの型
  */
-export interface ErrorResponse {
-  success: false;
-  error: {
-    message: string;
-    code: string;
-    details?: unknown;
-  };
-}
+export type ErrorResponse = Extract<ApiResponseDto, { success: false }>;
 
 /**
  * APIレスポンスの型（成功またはエラー）
  */
-export type ApiResponse<T = unknown> = SuccessResponse<T> | ErrorResponse;
+export type ApiResponse<T = unknown> = ApiResponseDto<T>;
 
 /**
  * ページネーション付きレスポンスの型
  */
-export interface PaginatedResponse<T> {
-  items: T[];
-  total: number;
-  limit: number;
-  offset: number;
-  hasMore: boolean;
-}
+export type PaginatedResponse<T> = PaginatedDto<T>;
 
 /**
  * 成功レスポンスを返す

--- a/app/server/lib/response.ts
+++ b/app/server/lib/response.ts
@@ -5,10 +5,7 @@ import type { ApiResponseDto, PaginatedDto } from "../../types/dto";
 /**
  * 成功レスポンスの型
  */
-export type SuccessResponse<T = unknown> = Extract<
-  ApiResponseDto<T>,
-  { success: true }
->;
+export type SuccessResponse<T = unknown> = Extract<ApiResponseDto<T>, { success: true }>;
 
 /**
  * エラーレスポンスの型

--- a/app/types/database.ts
+++ b/app/types/database.ts
@@ -88,27 +88,6 @@ export interface BookFilter {
   sortBy?: "title" | "created" | "updated" | "progress";
 }
 
-export interface BookResponse {
-  id: string;
-  userId: string;
-  rakutenBooksId: string | null;
-  title: string;
-  authors: string[];
-  publisher: string | null;
-  publishedDate: string | null;
-  isbn: string | null;
-  pageCount: number;
-  description: string | null;
-  thumbnailUrl: string | null;
-  rakutenAffiliateUrl: string | null;
-  status: BookStatus;
-  currentPage: number;
-  memo: string | null;
-  finishedAt: string | null;
-  createdAt: string;
-  updatedAt: string;
-}
-
 // タグ
 export interface Tag {
   id: string;


### PR DESCRIPTION
## 概要

- `BookResponse` を DB 型から分離し、`BookDto` を API 通信用の型として使うようにしました。
- mapper 名を `toBookDto` に変更しました。
- Books API と関連テストを `BookDto` / `BookStatsDto` 参照へ更新しました。
- `response.ts` の既存型は DTO 型への alias として残し、既存 import への影響を抑えました。

## 確認

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run app/server/api/books.test.ts app/server/api/tags.test.ts app/server/api/users.test.ts app/server/api/auth.test.ts app/server/api/search.test.ts app/server/services/rakuten.test.ts`

## 補足

- 楽天 API の `RakutenBookResponse` は外部 API 型なので、この PR では対象外です。