### PR TITLE
Tags APIをDTOへ寄せる

### DIFF
--- a/app/islands/TagInput.tsx
+++ b/app/islands/TagInput.tsx
@@ -1,26 +1,22 @@
 import { useState, useEffect } from "hono/jsx";
 import { getApiErrorMessage, readApiResponse } from "../lib/api-client";
-
-interface Tag {
-  id: string;
-  name: string;
-}
+import type { TagDto } from "../types/dto";
 
 interface TagInputProps {
   bookId: string;
-  initialTags?: Tag[];
+  initialTags?: TagDto[];
 }
 
 export default function TagInput({ bookId, initialTags = [] }: TagInputProps) {
-  const [tags, setTags] = useState<Tag[]>(initialTags);
-  const [allTags, setAllTags] = useState<Tag[]>([]);
+  const [tags, setTags] = useState<TagDto[]>(initialTags);
+  const [allTags, setAllTags] = useState<TagDto[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     // ユーザーのタグ一覧を取得
     fetch("/api/tags")
-      .then((res) => readApiResponse<Tag[]>(res))
+      .then((res) => readApiResponse<TagDto[]>(res))
       .then((data) => {
         if (data.success) {
           setAllTags(data.data);
@@ -52,7 +48,7 @@ export default function TagInput({ bookId, initialTags = [] }: TagInputProps) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ name }),
         });
-        const createData = await readApiResponse<Tag>(createRes);
+        const createData = await readApiResponse<TagDto>(createRes);
         if (createData.success) {
           tag = createData.data;
           setAllTags([...allTags, tag]);

--- a/app/server/api/tags.test.ts
+++ b/app/server/api/tags.test.ts
@@ -8,7 +8,7 @@ import {
   createTestTag,
 } from "../../test/helpers";
 import type { SuccessResponse } from "../lib/response";
-import type { TagResponse } from "../../types/database";
+import type { AddBookTagResponseDto, RemoveBookTagResponseDto, TagDto } from "../../types/dto";
 
 describe("Tags API Integration", () => {
   let userId: string;
@@ -36,7 +36,7 @@ describe("Tags API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<TagResponse[]>;
+      const body = (await res.json()) as SuccessResponse<TagDto[]>;
       expect(body.success).toBe(true);
       expect(body.data).toEqual([]);
     });
@@ -54,7 +54,7 @@ describe("Tags API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<TagResponse[]>;
+      const body = (await res.json()) as SuccessResponse<TagDto[]>;
       expect(body.data).toHaveLength(2);
     });
   });
@@ -75,7 +75,7 @@ describe("Tags API Integration", () => {
       );
 
       expect(res.status).toBe(201);
-      const body = (await res.json()) as SuccessResponse<TagResponse>;
+      const body = (await res.json()) as SuccessResponse<TagDto>;
       expect(body.success).toBe(true);
       expect(body.data.name).toBe("React");
     });
@@ -99,7 +99,7 @@ describe("Tags API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<TagResponse>;
+      const body = (await res.json()) as SuccessResponse<TagDto>;
       expect(body.data.name).toBe("NewName");
     });
   });
@@ -140,7 +140,7 @@ describe("Tags API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<TagResponse[]>;
+      const body = (await res.json()) as SuccessResponse<TagDto[]>;
       expect(body.data).toHaveLength(1);
     });
 
@@ -162,7 +162,7 @@ describe("Tags API Integration", () => {
       );
 
       expect(res.status).toBe(201);
-      const body = (await res.json()) as SuccessResponse<{ added: boolean }>;
+      const body = (await res.json()) as SuccessResponse<AddBookTagResponseDto>;
       expect(body.data.added).toBe(true);
     });
 
@@ -183,7 +183,7 @@ describe("Tags API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<{ removed: boolean }>;
+      const body = (await res.json()) as SuccessResponse<RemoveBookTagResponseDto>;
       expect(body.data.removed).toBe(true);
     });
   });

--- a/app/server/api/tags.ts
+++ b/app/server/api/tags.ts
@@ -11,7 +11,7 @@ import {
   bookIdParamSchema,
 } from "./schemas";
 import type { CreateTagInput, UpdateTagInput, AddTagToBookInput } from "./schemas/tag";
-import { toTagInput, toTagResponse } from "../lib/mapper";
+import { toTagDto, toTagInput } from "../lib/mapper";
 import { successResponse } from "../lib/response";
 
 const app = new Hono<HonoContext>();
@@ -27,7 +27,7 @@ app.get("/", async (c) => {
   const userId = c.get("userId");
   const tags = await tagRepo.findByUserId(c.env.DB, userId);
 
-  return successResponse(c, tags.map(toTagResponse));
+  return successResponse(c, tags.map(toTagDto));
 });
 
 /**
@@ -41,7 +41,7 @@ app.post("/", validator("json", createTagSchema), async (c) => {
   const tagInput = toTagInput(data, userId);
   const tag = await tagRepo.create(c.env.DB, tagInput);
 
-  return successResponse(c, toTagResponse(tag), 201);
+  return successResponse(c, toTagDto(tag), 201);
 });
 
 /**
@@ -55,7 +55,7 @@ app.put("/:id", validator("param", tagIdSchema), validator("json", updateTagSche
 
   const tag = await tagRepo.update(c.env.DB, id, userId, data.name);
 
-  return successResponse(c, toTagResponse(tag));
+  return successResponse(c, toTagDto(tag));
 });
 
 /**
@@ -113,7 +113,7 @@ app.get("/books/:bookId", async (c) => {
 
   const tags = await bookTagRepo.findTagsByBookId(c.env.DB, bookId);
 
-  return successResponse(c, tags.map(toTagResponse));
+  return successResponse(c, tags.map(toTagDto));
 });
 
 export default app;

--- a/app/server/lib/mapper.ts
+++ b/app/server/lib/mapper.ts
@@ -3,11 +3,10 @@ import type {
   BookInput,
   Tag,
   TagInput,
-  TagResponse,
   User,
   UserResponse,
 } from "../../types/database";
-import type { BookDto } from "../../types/dto";
+import type { BookDto, TagDto } from "../../types/dto";
 import type { CreateBookInput, UpdateBookInput } from "../api/schemas/book";
 import type { CreateTagInput } from "../api/schemas/tag";
 import { removeUndefined } from "./utils";
@@ -102,7 +101,7 @@ export function toTagInput(data: CreateTagInput, userId: string): TagInput {
 /**
  * DB形式のTagをAPI形式に変換
  */
-export function toTagResponse(tag: Tag): TagResponse {
+export function toTagDto(tag: Tag): TagDto {
   return {
     id: tag.id,
     userId: tag.user_id,

--- a/app/server/lib/mapper.ts
+++ b/app/server/lib/mapper.ts
@@ -1,11 +1,4 @@
-import type {
-  Book,
-  BookInput,
-  Tag,
-  TagInput,
-  User,
-  UserResponse,
-} from "../../types/database";
+import type { Book, BookInput, Tag, TagInput, User, UserResponse } from "../../types/database";
 import type { BookDto, TagDto } from "../../types/dto";
 import type { CreateBookInput, UpdateBookInput } from "../api/schemas/book";
 import type { CreateTagInput } from "../api/schemas/tag";

--- a/app/types/database.ts
+++ b/app/types/database.ts
@@ -103,13 +103,6 @@ export interface TagInput {
   createdAt: string;
 }
 
-export interface TagResponse {
-  id: string;
-  userId: string;
-  name: string;
-  createdAt: string;
-}
-
 // 書籍-タグ
 export interface BookTag {
   book_id: string;

--- a/app/types/dto/index.ts
+++ b/app/types/dto/index.ts
@@ -1,3 +1,4 @@
 export type * from "./book";
 export type * from "./common";
 export type * from "./search";
+export type * from "./tag";

--- a/app/types/dto/tag.ts
+++ b/app/types/dto/tag.ts
@@ -1,0 +1,26 @@
+export interface TagDto {
+  id: string;
+  userId: string;
+  name: string;
+  createdAt: string;
+}
+
+export interface CreateTagRequestDto {
+  name: string;
+}
+
+export interface UpdateTagRequestDto {
+  name: string;
+}
+
+export interface AddBookTagRequestDto {
+  tagId: string;
+}
+
+export interface AddBookTagResponseDto {
+  added: boolean;
+}
+
+export interface RemoveBookTagResponseDto {
+  removed: boolean;
+}


### PR DESCRIPTION
## 概要

- `TagDto` とタグ関連の request/response DTO を追加しました。
- `TagResponse` を DB 型から分離し、mapper 名を `toTagDto` に変更しました。
- Tags API、関連テスト、タグ入力 island を DTO 参照へ更新しました。

## 確認

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run app/server/api/books.test.ts app/server/api/tags.test.ts app/server/api/users.test.ts app/server/api/auth.test.ts app/server/api/search.test.ts app/server/services/rakuten.test.ts`

## 補足

- タグの API 形状は変更せず、通信契約の型名と置き場だけを整理しています。