### PR TITLE
UsersとAuth APIをDTOへ寄せる

### DIFF
--- a/app/islands/ProfileForm.tsx
+++ b/app/islands/ProfileForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "hono/jsx";
 import { getApiErrorMessage, readApiResponse } from "../lib/api-client";
+import type { UserDto } from "../types/dto";
 
 interface ProfileFormProps {
   avatarUrl: string | null;
@@ -40,11 +41,7 @@ export default function ProfileForm({
         body: JSON.stringify(body),
       });
 
-      const data = await readApiResponse<{
-        username: string;
-        name: string;
-        bio: string | null;
-      }>(res);
+      const data = await readApiResponse<UserDto>(res);
 
       if (res.ok) {
         setSaved(true);

--- a/app/server/api/auth.test.ts
+++ b/app/server/api/auth.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { env } from "cloudflare:test";
 import api from "./index";
 import { createTestSession, createTestUser, cleanupDatabase } from "../../test/helpers";
+import type { ApiResponseDto, AuthSessionDto, LogoutResponseDto } from "../../types/dto";
 
 describe("Auth API Integration", () => {
   beforeEach(async () => {
@@ -37,9 +38,12 @@ describe("Auth API Integration", () => {
 
     const res = await api.request(`/auth/google/callback?code=123&state=${state}`, {}, env);
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { success: boolean; error: { code: string } };
+    const body = (await res.json()) as ApiResponseDto;
     expect(body.success).toBe(false);
-    expect(body.error.code).toBe("INVALID_STATE");
+    expect(body.success).toBe(false);
+    if (!body.success) {
+      expect(body.error.code).toBe("INVALID_STATE");
+    }
   });
 
   it("should return session info for authenticated user", async () => {
@@ -55,13 +59,12 @@ describe("Auth API Integration", () => {
     );
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      success: boolean;
-      data: { authenticated: boolean; user: { id: string } };
-    };
+    const body = (await res.json()) as ApiResponseDto<AuthSessionDto>;
     expect(body.success).toBe(true);
-    expect(body.data.authenticated).toBe(true);
-    expect(body.data.user.id).toBe(user.id);
+    if (body.success) {
+      expect(body.data.authenticated).toBe(true);
+      expect(body.data.user.id).toBe(user.id);
+    }
   });
 
   it("should delete session on logout", async () => {
@@ -78,6 +81,11 @@ describe("Auth API Integration", () => {
     );
 
     expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponseDto<LogoutResponseDto>;
+    expect(body.success).toBe(true);
+    if (body.success) {
+      expect(body.data.loggedOut).toBe(true);
+    }
     const session = await env.KV.get(`session:${sessionId}`);
     expect(session).toBeNull();
   });

--- a/app/server/api/auth.ts
+++ b/app/server/api/auth.ts
@@ -7,7 +7,7 @@ import { validator, getValidated } from "../lib/validator";
 import { oauthProviderParamSchema, oauthCallbackSchema } from "./schemas";
 import type { OAuthProvider, OAuthCallbackInput } from "./schemas/auth";
 import { deleteSession, regenerateSession, SESSION_COOKIE_OPTIONS } from "../lib/session";
-import { toUserResponse } from "../lib/mapper";
+import { toUserDto } from "../lib/mapper";
 import { successResponse, errorResponse } from "../lib/response";
 import * as oauthService from "../services/oauth";
 import { authRateLimiter } from "../lib/rate-limit";
@@ -41,7 +41,7 @@ app.get("/session", authMiddleware, async (c) => {
   const user = c.get("user");
   return successResponse(c, {
     authenticated: true,
-    user: toUserResponse(user),
+    user: toUserDto(user),
   });
 });
 

--- a/app/server/api/users.test.ts
+++ b/app/server/api/users.test.ts
@@ -7,6 +7,14 @@ import {
   createTestUser,
   cleanupDatabase,
 } from "../../test/helpers";
+import type {
+  DeletedResponseDto,
+  PublicBookDto,
+  PublicProfileDto,
+  SuccessResponseDto,
+  UserDto,
+  UsernameAvailabilityDto,
+} from "../../types/dto";
 
 describe("Users API Integration", () => {
   beforeEach(async () => {
@@ -31,7 +39,7 @@ describe("Users API Integration", () => {
     );
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { success: boolean; data: { id: string; username: string } };
+    const body = (await res.json()) as SuccessResponseDto<UserDto>;
     expect(body.success).toBe(true);
     expect(body.data.id).toBe(user.id);
     expect(body.data.username).toBe(user.username);
@@ -81,10 +89,7 @@ describe("Users API Integration", () => {
     );
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      success: boolean;
-      data: { name: string; bio: string; avatarUrl: string };
-    };
+    const body = (await res.json()) as SuccessResponseDto<UserDto>;
     expect(body.data.name).toBe("Updated Name");
     expect(body.data.bio).toBe("Updated bio");
     expect(body.data.avatarUrl).toBe("https://example.com/avatar.png");
@@ -93,10 +98,7 @@ describe("Users API Integration", () => {
   it("should return unavailable for reserved username check", async () => {
     const res = await api.request("/users/check/admin", {}, env);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      success: boolean;
-      data: { available: boolean; reason?: string };
-    };
+    const body = (await res.json()) as SuccessResponseDto<UsernameAvailabilityDto>;
     expect(body.data.available).toBe(false);
     expect(body.data.reason).toBe("reserved");
   });
@@ -106,7 +108,7 @@ describe("Users API Integration", () => {
 
     const res = await api.request(`/users/check/${user.username}`, {}, env);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { success: boolean; data: { available: boolean } };
+    const body = (await res.json()) as SuccessResponseDto<UsernameAvailabilityDto>;
     expect(body.data.available).toBe(false);
   });
 
@@ -115,7 +117,7 @@ describe("Users API Integration", () => {
 
     const res = await api.request(`/users/${user.username}`, {}, env);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { success: boolean; data: Record<string, unknown> };
+    const body = (await res.json()) as SuccessResponseDto<PublicProfileDto>;
     expect(body.data.username).toBe(user.username);
     expect("email" in body.data).toBe(false);
     expect("provider" in body.data).toBe(false);
@@ -128,10 +130,7 @@ describe("Users API Integration", () => {
 
     const res = await api.request(`/users/${user.username}/books`, {}, env);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      success: boolean;
-      data: Array<{ status: string; memo: string | null }>;
-    };
+    const body = (await res.json()) as SuccessResponseDto<PublicBookDto[]>;
     expect(body.data).toHaveLength(1);
     expect(body.data[0].status).toBe("completed");
     expect(body.data[0].memo).toBeNull();
@@ -151,6 +150,8 @@ describe("Users API Integration", () => {
     );
 
     expect(res.status).toBe(200);
+    const body = (await res.json()) as SuccessResponseDto<DeletedResponseDto>;
+    expect(body.data.deleted).toBe(true);
     const result = await env.DB.prepare("SELECT id FROM users WHERE id = ?").bind(user.id).first();
     expect(result).toBeNull();
   });

--- a/app/server/api/users.ts
+++ b/app/server/api/users.ts
@@ -6,7 +6,7 @@ import { validator, getValidated } from "../lib/validator";
 import { updateUserSchema, usernameSchema } from "./schemas";
 import type { UpdateUserInput } from "./schemas/user";
 import { isReservedUsername } from "./schemas/user";
-import { toBookDto, toUserResponse } from "../lib/mapper";
+import { toBookDto, toUserDto } from "../lib/mapper";
 import { successResponse } from "../lib/response";
 import { invalidateUserCache } from "../lib/auth";
 
@@ -18,7 +18,7 @@ const app = new Hono<HonoContext>();
  */
 app.get("/me", authMiddleware, async (c) => {
   const user = c.get("user");
-  return successResponse(c, toUserResponse(user));
+  return successResponse(c, toUserDto(user));
 });
 
 /**
@@ -42,7 +42,7 @@ app.put("/me", authMiddleware, validator("json", updateUserSchema), async (c) =>
 
   await invalidateUserCache(c.env.KV, userId);
 
-  return successResponse(c, toUserResponse(updatedUser));
+  return successResponse(c, toUserDto(updatedUser));
 });
 
 /**

--- a/app/server/lib/mapper.ts
+++ b/app/server/lib/mapper.ts
@@ -1,5 +1,5 @@
-import type { Book, BookInput, Tag, TagInput, User, UserResponse } from "../../types/database";
-import type { BookDto, TagDto } from "../../types/dto";
+import type { Book, BookInput, Tag, TagInput, User } from "../../types/database";
+import type { BookDto, TagDto, UserDto } from "../../types/dto";
 import type { CreateBookInput, UpdateBookInput } from "../api/schemas/book";
 import type { CreateTagInput } from "../api/schemas/tag";
 import { removeUndefined } from "./utils";
@@ -106,7 +106,7 @@ export function toTagDto(tag: Tag): TagDto {
 /**
  * DB形式のUserをAPI形式に変換
  */
-export function toUserResponse(user: User): UserResponse {
+export function toUserDto(user: User): UserDto {
   return {
     id: user.id,
     username: user.username,

--- a/app/server/lib/response.ts
+++ b/app/server/lib/response.ts
@@ -1,16 +1,21 @@
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import type { ApiResponseDto, PaginatedDto } from "../../types/dto";
+import type {
+  ApiResponseDto,
+  ErrorResponseDto,
+  PaginatedDto,
+  SuccessResponseDto,
+} from "../../types/dto";
 
 /**
  * 成功レスポンスの型
  */
-export type SuccessResponse<T = unknown> = Extract<ApiResponseDto<T>, { success: true }>;
+export type SuccessResponse<T = unknown> = SuccessResponseDto<T>;
 
 /**
  * エラーレスポンスの型
  */
-export type ErrorResponse = Extract<ApiResponseDto, { success: false }>;
+export type ErrorResponse = ErrorResponseDto;
 
 /**
  * APIレスポンスの型（成功またはエラー）

--- a/app/types/database.ts
+++ b/app/types/database.ts
@@ -25,18 +25,6 @@ export interface UserInput {
   updated_at: string;
 }
 
-export interface UserResponse {
-  id: string;
-  username: string;
-  email: string;
-  name: string;
-  bio: string | null;
-  avatarUrl: string | null;
-  provider: "github" | "google";
-  createdAt: string;
-  updatedAt: string;
-}
-
 // 書籍
 export type BookStatus = "unread" | "reading" | "completed";
 

--- a/app/types/dto/auth.ts
+++ b/app/types/dto/auth.ts
@@ -1,0 +1,10 @@
+import type { UserDto } from "./user";
+
+export interface AuthSessionDto {
+  authenticated: true;
+  user: UserDto;
+}
+
+export interface LogoutResponseDto {
+  loggedOut: boolean;
+}

--- a/app/types/dto/book.ts
+++ b/app/types/dto/book.ts
@@ -1,4 +1,5 @@
 import type { BookStatus } from "../database";
+import type { TagDto } from "./tag";
 
 export interface BookDto {
   id: string;
@@ -22,7 +23,7 @@ export interface BookDto {
 }
 
 export interface BookDetailDto extends BookDto {
-  tags: string[];
+  tags: TagDto[];
 }
 
 export interface CreateBookRequestDto {

--- a/app/types/dto/common.ts
+++ b/app/types/dto/common.ts
@@ -14,6 +14,10 @@ export type ApiResponseDto<T = unknown> =
       error: ApiErrorDto;
     };
 
+export type SuccessResponseDto<T = unknown> = Extract<ApiResponseDto<T>, { success: true }>;
+
+export type ErrorResponseDto = Extract<ApiResponseDto, { success: false }>;
+
 export interface PaginatedDto<T> {
   items: T[];
   total: number;

--- a/app/types/dto/index.ts
+++ b/app/types/dto/index.ts
@@ -2,3 +2,5 @@ export type * from "./book";
 export type * from "./common";
 export type * from "./search";
 export type * from "./tag";
+export type * from "./user";
+export type * from "./auth";

--- a/app/types/dto/user.ts
+++ b/app/types/dto/user.ts
@@ -1,0 +1,37 @@
+import type { BookDto } from "./book";
+
+export interface UserDto {
+  id: string;
+  username: string;
+  email: string;
+  name: string;
+  bio: string | null;
+  avatarUrl: string | null;
+  provider: "github" | "google";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateUserRequestDto {
+  username?: string;
+  name?: string;
+  bio?: string;
+  avatarUrl?: string;
+}
+
+export interface UsernameAvailabilityDto {
+  available: boolean;
+  reason?: "reserved";
+}
+
+export interface PublicProfileDto {
+  id: string;
+  username: string;
+  name: string;
+  bio: string | null;
+  avatarUrl: string | null;
+}
+
+export interface PublicBookDto extends BookDto {
+  memo: null;
+}


### PR DESCRIPTION
## 概要

- `UserDto`、公開プロフィール、公開書籍、ユーザー名確認、Auth session/logout の DTO を追加しました。
- `UserResponse` を DB 型から分離し、mapper 名を `toUserDto` に変更しました。
- Users/Auth API、関連テスト、プロフィールフォームの型参照を DTO に更新しました。
- 共通 DTO に `SuccessResponseDto` / `ErrorResponseDto` を追加し、server response helper の型 alias と揃えました。

## 確認

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run app/server/api/books.test.ts app/server/api/tags.test.ts app/server/api/users.test.ts app/server/api/auth.test.ts app/server/api/search.test.ts app/server/services/rakuten.test.ts`

## 補足

- 既存の API 形状は維持し、DB 型と API DTO の責務分離を進めています。