### PR TITLE
DTO境界の残差を整理

### DIFF
--- a/app/components/book/BookCard.tsx
+++ b/app/components/book/BookCard.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "hono/jsx";
-import type { BookStatus } from "../../types/database";
+import type { BookStatus } from "../../types/book";
 import { Card, CardBody } from "../ui/Card";
 import { StatusBadge } from "../ui/Badge";
 import { ProgressBar } from "../ui/ProgressBar";

--- a/app/components/book/BookList.tsx
+++ b/app/components/book/BookList.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "hono/jsx";
-import type { BookStatus } from "../../types/database";
+import type { BookStatus } from "../../types/book";
 import { BookCard } from "./BookCard";
 
 interface BookItem {

--- a/app/components/ui/Badge.tsx
+++ b/app/components/ui/Badge.tsx
@@ -1,5 +1,5 @@
 import type { FC, PropsWithChildren } from "hono/jsx";
-import type { BookStatus } from "../../types/database";
+import type { BookStatus } from "../../types/book";
 
 type BadgeVariant = "default" | "success" | "warning" | "info" | "danger";
 

--- a/app/islands/BooksStatusTabs.tsx
+++ b/app/islands/BooksStatusTabs.tsx
@@ -1,5 +1,5 @@
 import { useState } from "hono/jsx/dom";
-import type { BookStatus } from "../types/database";
+import type { BookStatus } from "../types/book";
 import { BookCover } from "../components/book/BookCover";
 
 interface BookItem {

--- a/app/islands/ProfileBookTabs.tsx
+++ b/app/islands/ProfileBookTabs.tsx
@@ -1,5 +1,5 @@
 import { useState } from "hono/jsx/dom";
-import type { BookStatus } from "../types/database";
+import type { BookStatus } from "../types/book";
 import { BookCover } from "../components/book/BookCover";
 import { Card, CardBody } from "../components/ui/Card";
 

--- a/app/routes/books/index.tsx
+++ b/app/routes/books/index.tsx
@@ -4,7 +4,8 @@ import { Layout } from "../../components/layout/Layout";
 import { Button } from "../../components/ui/Button";
 import BooksStatusTabs from "../../islands/BooksStatusTabs";
 import { bookRepo } from "../../server/db/repositories";
-import type { Book, BookStatus } from "../../types/database";
+import type { BookStatus } from "../../types/book";
+import type { Book } from "../../types/database";
 
 const formatBooks = (bookList: Book[]) =>
   bookList.map((book) => ({

--- a/app/routes/user/[username].tsx
+++ b/app/routes/user/[username].tsx
@@ -6,7 +6,8 @@ import { UserProfile } from "../../components/user/UserProfile";
 import { UserStats } from "../../components/user/UserStats";
 import ProfileBookTabs from "../../islands/ProfileBookTabs";
 import { userRepo, bookRepo } from "../../server/db/repositories";
-import type { User, Book, BookStats, BookStatus } from "../../types/database";
+import type { BookStatus } from "../../types/book";
+import type { User, Book, BookStats } from "../../types/database";
 
 interface BookListItem {
   id: string;

--- a/app/server/api/books.test.ts
+++ b/app/server/api/books.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { env } from "cloudflare:test";
 import api from "./index";
-import { createTestUser, createTestSession, createTestBook } from "../../test/helpers";
+import {
+  createTestUser,
+  createTestSession,
+  createTestBook,
+  createTestTag,
+} from "../../test/helpers";
 import type { SuccessResponse, PaginatedResponse } from "../lib/response";
-import type { BookDto, BookStatsDto } from "../../types/dto";
+import type { BookDetailDto, BookDto, BookStatsDto } from "../../types/dto";
 
 describe("Books API Integration", () => {
   let userId: string;
@@ -209,6 +214,10 @@ describe("Books API Integration", () => {
   describe("GET /books/:id", () => {
     it("should return a book by id", async () => {
       const book = await createTestBook(env.DB, userId, { title: "My Book" });
+      const tag = await createTestTag(env.DB, userId, "API");
+      await env.DB.prepare("INSERT INTO book_tags (book_id, tag_id) VALUES (?, ?)")
+        .bind(book.id, tag.id)
+        .run();
 
       const res = await api.request(
         `/books/${book.id}`,
@@ -219,8 +228,13 @@ describe("Books API Integration", () => {
       );
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as SuccessResponse<BookDto>;
+      const body = (await res.json()) as SuccessResponse<BookDetailDto>;
       expect(body.data.title).toBe("My Book");
+      expect(body.data.tags).toHaveLength(1);
+      expect(body.data.tags[0].name).toBe("API");
+      expect(body.data.tags[0].createdAt).toBe(tag.created_at);
+      expect("created_at" in body.data.tags[0]).toBe(false);
+      expect("user_id" in body.data.tags[0]).toBe(false);
     });
 
     // Note: 404 test is skipped because the current error handler wraps NotFoundError in DatabaseError

--- a/app/server/api/books.ts
+++ b/app/server/api/books.ts
@@ -16,7 +16,7 @@ import type {
   ProgressInput,
   BookFilterInput,
 } from "./schemas/book";
-import { toBookDto, toBookInput, toBookUpdateInput } from "../lib/mapper";
+import { toBookDto, toBookInput, toBookUpdateInput, toTagDto } from "../lib/mapper";
 import { bookDomain } from "../domain";
 import { successResponse, paginatedResponse } from "../lib/response";
 import { ValidationError } from "../lib/errors";
@@ -74,7 +74,7 @@ app.get("/:id", validator("param", bookIdSchema), async (c) => {
 
   return successResponse(c, {
     ...toBookDto(book),
-    tags,
+    tags: tags.map(toTagDto),
   });
 });
 

--- a/app/server/api/search.test.ts
+++ b/app/server/api/search.test.ts
@@ -3,6 +3,7 @@ import { env } from "cloudflare:test";
 import api from "./index";
 import { createTestSession, createTestUser, cleanupDatabase } from "../../test/helpers";
 import type {
+  ErrorResponseDto,
   SearchBookByIsbnResponseDto,
   SearchBooksResponseDto,
   SuccessResponseDto,
@@ -35,6 +36,9 @@ describe("Search API Integration", () => {
     );
 
     expect(res.status).toBe(400);
+    const body = (await res.json()) as ErrorResponseDto;
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("VALIDATION_ERROR");
   });
 
   it("should return search results sorted by published date", async () => {
@@ -116,6 +120,10 @@ describe("Search API Integration", () => {
     );
 
     expect(res.status).toBe(400);
+    const body = (await res.json()) as ErrorResponseDto;
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    expect(body.error.details).toBe("Invalid ISBN");
   });
 
   it("should return null when ISBN search has no results", async () => {

--- a/app/server/api/search.ts
+++ b/app/server/api/search.ts
@@ -4,7 +4,7 @@ import { authMiddleware } from "../lib/auth";
 import { validator, getValidated } from "../lib/validator";
 import { rakutenSearchSchema, isbnSearchSchema } from "./schemas";
 import type { RakutenSearchInput } from "./schemas/auth";
-import { successResponse } from "../lib/response";
+import { errorResponse, successResponse } from "../lib/response";
 import { isValidISBN } from "../lib/validation";
 import * as rakutenService from "../services/rakuten";
 import { searchRateLimiter } from "../lib/rate-limit";
@@ -27,7 +27,7 @@ app.get("/books", validator("query", rakutenSearchSchema), async (c) => {
 
   // queryがundefinedの場合はエラーを返す
   if (!query) {
-    return c.json({ success: false, error: { message: "検索クエリが指定されていません" } }, 400);
+    return errorResponse(c, "検索クエリが指定されていません", "VALIDATION_ERROR", 400);
   }
 
   const { results, hits, pageCount } = await rakutenService.searchBooks(
@@ -54,17 +54,7 @@ app.get("/books", validator("query", rakutenSearchSchema), async (c) => {
 app.get("/isbn/:isbn", validator("param", isbnSearchSchema), async (c) => {
   const isbn = c.req.param("isbn");
   if (!isValidISBN(isbn)) {
-    return c.json(
-      {
-        success: false,
-        error: {
-          message: "Validation failed",
-          code: "VALIDATION_ERROR",
-          details: "Invalid ISBN",
-        },
-      },
-      400,
-    );
+    return errorResponse(c, "Validation failed", "VALIDATION_ERROR", 400, "Invalid ISBN");
   }
 
   const result = await rakutenService.searchByISBN(isbn, c.env.RAKUTEN_APP_ID);

--- a/app/server/api/users.test.ts
+++ b/app/server/api/users.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../test/helpers";
 import type {
   DeletedResponseDto,
+  ErrorResponseDto,
   PublicBookDto,
   PublicProfileDto,
   SuccessResponseDto,
@@ -63,8 +64,10 @@ describe("Users API Integration", () => {
     );
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error?: string };
-    expect(body.error).toBe("このユーザー名は使用できません");
+    const body = (await res.json()) as ErrorResponseDto;
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("RESERVED_USERNAME");
+    expect(body.error.message).toBe("このユーザー名は使用できません");
   });
 
   it("should update user profile fields", async () => {
@@ -134,6 +137,9 @@ describe("Users API Integration", () => {
     expect(body.data).toHaveLength(1);
     expect(body.data[0].status).toBe("completed");
     expect(body.data[0].memo).toBeNull();
+    expect("userId" in body.data[0]).toBe(false);
+    expect("rakutenBooksId" in body.data[0]).toBe(false);
+    expect("rakutenAffiliateUrl" in body.data[0]).toBe(false);
   });
 
   it("should delete user account", async () => {

--- a/app/server/api/users.ts
+++ b/app/server/api/users.ts
@@ -6,8 +6,8 @@ import { validator, getValidated } from "../lib/validator";
 import { updateUserSchema, usernameSchema } from "./schemas";
 import type { UpdateUserInput } from "./schemas/user";
 import { isReservedUsername } from "./schemas/user";
-import { toBookDto, toUserDto } from "../lib/mapper";
-import { successResponse } from "../lib/response";
+import { toPublicBookDto, toUserDto } from "../lib/mapper";
+import { errorResponse, successResponse } from "../lib/response";
 import { invalidateUserCache } from "../lib/auth";
 
 const app = new Hono<HonoContext>();
@@ -30,7 +30,7 @@ app.put("/me", authMiddleware, validator("json", updateUserSchema), async (c) =>
   const data = getValidated<UpdateUserInput>(c, "json");
 
   if (data.username && isReservedUsername(data.username)) {
-    return c.json({ error: "このユーザー名は使用できません" }, 400);
+    return errorResponse(c, "このユーザー名は使用できません", "RESERVED_USERNAME", 400);
   }
 
   const updatedUser = await userRepo.update(c.env.DB, userId, {
@@ -94,14 +94,7 @@ app.get("/:username/books", optionalAuthMiddleware, async (c) => {
     offset: 0,
   });
 
-  return successResponse(
-    c,
-    books.map((book) => {
-      const response = toBookDto(book);
-      response.memo = null;
-      return response;
-    }),
-  );
+  return successResponse(c, books.map(toPublicBookDto));
 });
 
 /**

--- a/app/server/db/repositories/book.ts
+++ b/app/server/db/repositories/book.ts
@@ -1,4 +1,5 @@
-import type { Book, BookInput, BookFilter, BookStats, BookStatus } from "../../../types/database";
+import type { BookStatus } from "../../../types/book";
+import type { Book, BookInput, BookFilter, BookStats } from "../../../types/database";
 import { NotFoundError, DatabaseError } from "../../lib/errors";
 
 import type { Env } from "../../../types/env";

--- a/app/server/domain/book.ts
+++ b/app/server/domain/book.ts
@@ -1,4 +1,4 @@
-import type { BookStatus } from "../../types/database";
+import type { BookStatus } from "../../types/book";
 
 /**
  * 進捗に基づいてステータスを計算

--- a/app/server/lib/mapper.ts
+++ b/app/server/lib/mapper.ts
@@ -1,5 +1,5 @@
 import type { Book, BookInput, Tag, TagInput, User } from "../../types/database";
-import type { BookDto, TagDto, UserDto } from "../../types/dto";
+import type { BookDto, PublicBookDto, TagDto, UserDto } from "../../types/dto";
 import type { CreateBookInput, UpdateBookInput } from "../api/schemas/book";
 import type { CreateTagInput } from "../api/schemas/tag";
 import { removeUndefined } from "./utils";
@@ -73,6 +73,29 @@ export function toBookDto(book: Book): BookDto {
     status: book.status,
     currentPage: book.current_page,
     memo: book.memo,
+    finishedAt: book.finished_at,
+    createdAt: book.created_at,
+    updatedAt: book.updated_at,
+  };
+}
+
+/**
+ * DB形式のBookを公開プロフィール用のAPI形式に変換
+ */
+export function toPublicBookDto(book: Book): PublicBookDto {
+  return {
+    id: book.id,
+    title: book.title,
+    authors: JSON.parse(book.authors),
+    publisher: book.publisher,
+    publishedDate: book.published_date,
+    isbn: book.isbn,
+    pageCount: book.page_count,
+    description: book.description,
+    thumbnailUrl: book.thumbnail_url,
+    status: book.status,
+    currentPage: book.current_page,
+    memo: null,
     finishedAt: book.finished_at,
     createdAt: book.created_at,
     updatedAt: book.updated_at,

--- a/app/test/helpers.ts
+++ b/app/test/helpers.ts
@@ -1,4 +1,5 @@
 import type { Env } from "../types/env";
+import type { BookStatus } from "../types/book";
 
 type D1Database = Env["DB"];
 type KVNamespace = Env["KV"];
@@ -73,7 +74,7 @@ export async function createTestBook(
     id: string;
     title: string;
     authors: string[];
-    status: "unread" | "reading" | "completed";
+    status: BookStatus;
     pageCount: number;
     currentPage: number;
   }> = {},

--- a/app/types/book.ts
+++ b/app/types/book.ts
@@ -1,0 +1,1 @@
+export type BookStatus = "unread" | "reading" | "completed";

--- a/app/types/database.ts
+++ b/app/types/database.ts
@@ -1,3 +1,5 @@
+import type { BookStatus } from "./book";
+
 // ユーザー
 export interface User {
   id: string;
@@ -24,9 +26,6 @@ export interface UserInput {
   created_at: string;
   updated_at: string;
 }
-
-// 書籍
-export type BookStatus = "unread" | "reading" | "completed";
 
 export interface Book {
   id: string;

--- a/app/types/dto/book.ts
+++ b/app/types/dto/book.ts
@@ -1,4 +1,4 @@
-import type { BookStatus } from "../database";
+import type { BookStatus } from "../book";
 import type { TagDto } from "./tag";
 
 export interface BookDto {

--- a/app/types/dto/user.ts
+++ b/app/types/dto/user.ts
@@ -1,4 +1,4 @@
-import type { BookDto } from "./book";
+import type { BookStatus } from "../book";
 
 export interface UserDto {
   id: string;
@@ -32,6 +32,20 @@ export interface PublicProfileDto {
   avatarUrl: string | null;
 }
 
-export interface PublicBookDto extends BookDto {
+export interface PublicBookDto {
+  id: string;
+  title: string;
+  authors: string[];
+  publisher: string | null;
+  publishedDate: string | null;
+  isbn: string | null;
+  pageCount: number;
+  description: string | null;
+  thumbnailUrl: string | null;
+  status: BookStatus;
+  currentPage: number;
   memo: null;
+  finishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
 }


### PR DESCRIPTION
## 概要

- 書籍詳細APIのタグ返却を `TagDto` に変換し、`BookDetailDto.tags` と実レスポンスを一致させました。
- 公開プロフィール用の `toPublicBookDto` を追加し、公開書籍レスポンスが private 用の `BookDto` に依存しないようにしました。
- `BookStatus` をDB型から切り離し、共有型として `app/types/book.ts` に移しました。
- 手書きのエラーレスポンスを `errorResponse()` 経由に寄せ、APIエラー形状を揃えました。

## 確認

- `PATH=/Users/Ojoxux/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/tsc --noEmit`
- `PATH=/Users/Ojoxux/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/vitest run app/server/api/books.test.ts app/server/api/users.test.ts app/server/api/search.test.ts --reporter verbose`

## 補足

- このPRのbaseは、#105までマージ済みの `codex/dto-users-auth` です。