### PR TITLE
fix: モバイル本リストのスクロールバウンスを解消

### DIFF
--- a/app/islands/mobile/Sidebar.tsx
+++ b/app/islands/mobile/Sidebar.tsx
@@ -20,8 +20,8 @@ export default function Sidebar({ showLogout = true }: SidebarProps) {
       const st = scrollTarget.scrollTop;
       const { show, scrolledDataset } = getScrollChromeState({
         scrollTop: st,
-        lastScrollTop: lastScrollTop.current,
-        currentlyShown: visibleRef.current,
+        lastScrollTop: lastScrollTop.current ?? 0,
+        currentlyShown: visibleRef.current ?? true,
       });
       visibleRef.current = show;
       setVisible(show);

--- a/app/islands/mobile/Sidebar.tsx
+++ b/app/islands/mobile/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "hono/jsx/dom";
+import { getScrollChromeState } from "../../lib/scroll-chrome";
 
 interface SidebarProps {
   showLogout?: boolean;
@@ -8,6 +9,7 @@ export default function Sidebar({ showLogout = true }: SidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [visible, setVisible] = useState(true);
   const lastScrollTop = useRef(0);
+  const visibleRef = useRef(true);
 
   useEffect(() => {
     const scrollTarget = document.querySelector("main");
@@ -16,9 +18,14 @@ export default function Sidebar({ showLogout = true }: SidebarProps) {
     const layout = document.getElementById("main-layout");
     const onScroll = () => {
       const st = scrollTarget.scrollTop;
-      const show = st <= 10 || st < (lastScrollTop.current ?? 0);
+      const { show, scrolledDataset } = getScrollChromeState({
+        scrollTop: st,
+        lastScrollTop: lastScrollTop.current,
+        currentlyShown: visibleRef.current,
+      });
+      visibleRef.current = show;
       setVisible(show);
-      if (layout) layout.dataset.scrolled = show ? "" : "down";
+      if (layout) layout.dataset.scrolled = scrolledDataset;
       lastScrollTop.current = st;
     };
 

--- a/app/lib/scroll-chrome.test.ts
+++ b/app/lib/scroll-chrome.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { getScrollChromeState } from "./scroll-chrome";
+
+describe("getScrollChromeState", () => {
+  it("shows chrome near the top even when scrolling down", () => {
+    expect(getScrollChromeState({ scrollTop: 8, lastScrollTop: 0, currentlyShown: true })).toEqual({
+      show: true,
+      scrolledDataset: "",
+    });
+  });
+
+  it("hides chrome after scrolling down past the hide delta", () => {
+    expect(
+      getScrollChromeState({ scrollTop: 40, lastScrollTop: 20, currentlyShown: true }),
+    ).toEqual({
+      show: false,
+      scrolledDataset: "down",
+    });
+  });
+
+  it("shows chrome after scrolling up past the show delta", () => {
+    expect(
+      getScrollChromeState({ scrollTop: 30, lastScrollTop: 50, currentlyShown: false }),
+    ).toEqual({
+      show: true,
+      scrolledDataset: "",
+    });
+  });
+
+  it("keeps the current state for small jitter so layout does not thrash", () => {
+    expect(
+      getScrollChromeState({ scrollTop: 42, lastScrollTop: 40, currentlyShown: false }),
+    ).toEqual({
+      show: false,
+      scrolledDataset: "down",
+    });
+
+    expect(
+      getScrollChromeState({ scrollTop: 38, lastScrollTop: 40, currentlyShown: true }),
+    ).toEqual({
+      show: true,
+      scrolledDataset: "",
+    });
+  });
+});

--- a/app/lib/scroll-chrome.ts
+++ b/app/lib/scroll-chrome.ts
@@ -1,0 +1,43 @@
+export type ScrollChromeState = {
+  show: boolean;
+  scrolledDataset: "" | "down";
+};
+
+type GetScrollChromeStateInput = {
+  scrollTop: number;
+  lastScrollTop: number;
+  currentlyShown: boolean;
+  topThreshold?: number;
+  hideDelta?: number;
+  showDelta?: number;
+};
+
+/**
+ * Decide whether mobile chrome (header / menu button) should stay visible.
+ * Uses deltas so tiny scroll jitter does not thrash show/hide.
+ */
+export function getScrollChromeState({
+  scrollTop,
+  lastScrollTop,
+  currentlyShown,
+  topThreshold = 10,
+  hideDelta = 8,
+  showDelta = 8,
+}: GetScrollChromeStateInput): ScrollChromeState {
+  if (scrollTop <= topThreshold) {
+    return { show: true, scrolledDataset: "" };
+  }
+
+  const delta = scrollTop - lastScrollTop;
+  if (delta > hideDelta) {
+    return { show: false, scrolledDataset: "down" };
+  }
+  if (delta < -showDelta) {
+    return { show: true, scrolledDataset: "" };
+  }
+
+  return {
+    show: currentlyShown,
+    scrolledDataset: currentlyShown ? "" : "down",
+  };
+}

--- a/app/style.css
+++ b/app/style.css
@@ -13,21 +13,31 @@
   animation: slide-in 0.2s ease-out;
 }
 
+/*
+ * Mobile scroll chrome: hide the header with transform/opacity only.
+ * Never animate height — that resizes <main> mid-scroll and causes bounce.
+ */
 @media (max-width: 767px) {
   #main-layout header {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 20;
+    background-color: #fff;
     transition:
-      height 0.3s,
-      opacity 0.3s,
-      overflow 0s 0.3s;
+      transform 0.3s ease,
+      opacity 0.3s ease;
   }
+
+  #main-layout main {
+    /* Reserve header space so content never jumps when chrome hides */
+    padding-top: 4rem;
+  }
+
   #main-layout[data-scrolled="down"] header {
-    height: 0;
+    transform: translateY(-100%);
     opacity: 0;
-    overflow: hidden;
     pointer-events: none;
-    transition:
-      height 0.3s,
-      opacity 0.3s,
-      overflow 0s;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- モバイルで下スクロール時にヘッダー `height` を `64px → 0` アニメーションしていたため、`<main>` の高さが変化して本リストがバウンスしていた問題を修正
- ヘッダー非表示を `transform` / `opacity` のみにし、`<main>` のサイズは固定（`padding-top: 4rem` でヘッダー分を確保）
- 微小スクロールで表示/非表示が切り替わらないよう、delta ベースのヒステリシスを追加

## Test plan
- [ ] モバイル幅で `/books` を開き、上下スクロールしてもリストが跳ねないこと
- [ ] 下スクロールでヘッダーとハンバーガーが消え、上スクロールで戻ること
- [ ] デスクトップでは従来どおりヘッダーが常に表示されること
- [ ] `pnpm test app/lib/scroll-chrome.test.ts` が通ること
- [x] `pnpm typecheck` 通過済み
- [x] `pnpm test app/lib/scroll-chrome.test.ts` 通過済み

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf4d7017-6584-4a8d-ae13-f212f2d65d4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf4d7017-6584-4a8d-ae13-f212f2d65d4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

