### PR TITLE
技術書っぽさ検索の落穂拾い

### DIFF
--- a/app/lib/book-search-ranking.test.ts
+++ b/app/lib/book-search-ranking.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { mergeRankedSearchResults } from "./book-search-ranking";
 
 interface TestSearchResult {
+  isbn: string;
   title: string;
   techScore: number;
   publishedDate: string;
@@ -10,11 +11,11 @@ interface TestSearchResult {
 describe("mergeRankedSearchResults", () => {
   it("should sort results from multiple pages by technical score", () => {
     const currentResults: TestSearchResult[] = [
-      { title: "Medium", techScore: 20, publishedDate: "2025年1月1日" },
-      { title: "Low", techScore: -40, publishedDate: "2026年1月1日" },
+      { isbn: "1", title: "Medium", techScore: 20, publishedDate: "2025年1月1日" },
+      { isbn: "2", title: "Low", techScore: -40, publishedDate: "2026年1月1日" },
     ];
     const additionalResults: TestSearchResult[] = [
-      { title: "High", techScore: 50, publishedDate: "2020年1月1日" },
+      { isbn: "3", title: "High", techScore: 50, publishedDate: "2020年1月1日" },
     ];
 
     const merged = mergeRankedSearchResults(currentResults, additionalResults);
@@ -24,11 +25,11 @@ describe("mergeRankedSearchResults", () => {
 
   it("should prefer newer publications when technical scores are tied", () => {
     const currentResults: TestSearchResult[] = [
-      { title: "Older", techScore: 15, publishedDate: "2020年1月1日" },
+      { isbn: "1", title: "Older", techScore: 15, publishedDate: "2020年1月1日" },
     ];
     const additionalResults: TestSearchResult[] = [
-      { title: "Unknown", techScore: 15, publishedDate: "unknown" },
-      { title: "Newer", techScore: 15, publishedDate: "2025年1月1日" },
+      { isbn: "2", title: "Unknown", techScore: 15, publishedDate: "unknown" },
+      { isbn: "3", title: "Newer", techScore: 15, publishedDate: "2025年1月1日" },
     ];
 
     const merged = mergeRankedSearchResults(currentResults, additionalResults);
@@ -38,10 +39,10 @@ describe("mergeRankedSearchResults", () => {
 
   it("should not mutate either input array", () => {
     const currentResults: TestSearchResult[] = [
-      { title: "Current", techScore: 0, publishedDate: "2025年1月1日" },
+      { isbn: "1", title: "Current", techScore: 0, publishedDate: "2025年1月1日" },
     ];
     const additionalResults: TestSearchResult[] = [
-      { title: "Additional", techScore: 30, publishedDate: "2024年1月1日" },
+      { isbn: "2", title: "Additional", techScore: 30, publishedDate: "2024年1月1日" },
     ];
     const originalCurrentResults = structuredClone(currentResults);
     const originalAdditionalResults = structuredClone(additionalResults);
@@ -50,5 +51,41 @@ describe("mergeRankedSearchResults", () => {
 
     expect(currentResults).toEqual(originalCurrentResults);
     expect(additionalResults).toEqual(originalAdditionalResults);
+  });
+
+  it("should remove duplicate ISBNs across pages", () => {
+    const currentResults: TestSearchResult[] = [
+      {
+        isbn: "978-4-1234-5678-9",
+        title: "Current",
+        techScore: 10,
+        publishedDate: "2024年1月1日",
+      },
+    ];
+    const additionalResults: TestSearchResult[] = [
+      {
+        isbn: "9784123456789",
+        title: "Duplicate",
+        techScore: 20,
+        publishedDate: "2025年1月1日",
+      },
+    ];
+
+    const merged = mergeRankedSearchResults(currentResults, additionalResults);
+
+    expect(merged.map((result) => result.title)).toEqual(["Current"]);
+  });
+
+  it("should keep results without an ISBN", () => {
+    const currentResults: TestSearchResult[] = [
+      { isbn: "", title: "Current", techScore: 10, publishedDate: "2024年1月1日" },
+    ];
+    const additionalResults: TestSearchResult[] = [
+      { isbn: "", title: "Additional", techScore: 20, publishedDate: "2025年1月1日" },
+    ];
+
+    const merged = mergeRankedSearchResults(currentResults, additionalResults);
+
+    expect(merged.map((result) => result.title)).toEqual(["Additional", "Current"]);
   });
 });

--- a/app/lib/book-search-ranking.ts
+++ b/app/lib/book-search-ranking.ts
@@ -1,4 +1,5 @@
 export interface RankedSearchResult {
+  isbn: string;
   techScore: number;
   publishedDate: string;
 }
@@ -7,7 +8,18 @@ export function mergeRankedSearchResults<T extends RankedSearchResult>(
   currentResults: T[],
   additionalResults: T[],
 ): T[] {
-  return [...currentResults, ...additionalResults].toSorted(compareRankedSearchResults);
+  const seenIsbns = new Set<string>();
+
+  return [...currentResults, ...additionalResults]
+    .filter((result) => {
+      const isbn = result.isbn.replace(/[-\s]/g, "");
+      if (!isbn) return true;
+      if (seenIsbns.has(isbn)) return false;
+
+      seenIsbns.add(isbn);
+      return true;
+    })
+    .toSorted(compareRankedSearchResults);
 }
 
 export function compareRankedSearchResults(

--- a/app/server/api/search.test.ts
+++ b/app/server/api/search.test.ts
@@ -109,7 +109,7 @@ describe("Search API Integration", () => {
     expect(body.data.pageCount).toBe(1);
   });
 
-  it("should include score reasons when debug is enabled", async () => {
+  it.each(["1", "true"])("should include score reasons when debug=%s", async (debug) => {
     const user = await createTestUser(env.DB);
     const sessionId = await createTestSession(env.KV, user.id);
 
@@ -145,7 +145,7 @@ describe("Search API Integration", () => {
     );
 
     const res = await api.request(
-      "/search/books?query=docker&debug=1",
+      `/search/books?query=docker&debug=${debug}`,
       {
         headers: { Cookie: `session_id=${sessionId}` },
       },

--- a/app/server/services/rakuten.test.ts
+++ b/app/server/services/rakuten.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { searchBooks, searchByISBN, searchByAuthor, sortByPublishedDateDesc } from "./rakuten";
+import { searchBooks, searchByISBN, searchByAuthor } from "./rakuten";
 
 describe("rakuten service", () => {
   afterEach(() => {
@@ -184,16 +184,6 @@ describe("rakuten service", () => {
       expect.stringContaining('"upstreamDescription":"accessKey must be present"'),
     );
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('"willRetry":false'));
-  });
-
-  it("should sort by published date desc", () => {
-    const sorted = sortByPublishedDateDesc([
-      { title: "Old", publishedDate: "2020年1月1日" } as never,
-      { title: "New", publishedDate: "2024年1月1日" } as never,
-      { title: "Unknown", publishedDate: "invalid" } as never,
-    ]);
-    expect(sorted[0].title).toBe("New");
-    expect(sorted[sorted.length - 1].title).toBe("Unknown");
   });
 
   it("should parse authors separated by Japanese comma", async () => {

--- a/app/server/services/rakuten.ts
+++ b/app/server/services/rakuten.ts
@@ -242,34 +242,3 @@ function parsePageCount(size: string): number {
   const match = size.match(/(\d+)/);
   return match ? parseInt(match[1], 10) : 0;
 }
-
-/**
- * 出版日の最新順での並び替え
- */
-
-function parsePublishedDate(publishedDate: string): Date | null {
-  if (!publishedDate) return null;
-
-  const match = publishedDate.match(/(\d{4})年(\d{1,2})月(\d{1,2})日/);
-  if (!match) return null;
-
-  const [, year, month, day] = match;
-
-  return new Date(Number(year), Number(month) - 1, Number(day));
-}
-
-/**
- * 本の配列を、出版日が新しい順に並び替え
- */
-export function sortByPublishedDateDesc(books: BookSearchResultDto[]): BookSearchResultDto[] {
-  return [...books].sort((before, after) => {
-    const beforeDate = parsePublishedDate(before.publishedDate);
-    const afterDate = parsePublishedDate(after.publishedDate);
-
-    if (!beforeDate && !afterDate) return 0;
-    if (!beforeDate) return 1;
-    if (!afterDate) return -1;
-
-    return afterDate.getTime() - beforeDate.getTime();
-  });
-}


### PR DESCRIPTION
## 概要

- 「もっと見る」で検索結果を結合する際、同一ISBNの書籍を重複排除するように変更
- 楽天サービスに残っていた未使用の出版日並び替え処理とテストを削除
- 検索APIのデバッグ指定について、`debug=1` と `debug=true` の両方を結合テストで確認

## 確認

- `pnpm test`（245件成功）
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`