### PR TITLE
書籍登録後の導線に完了ページを追加

### DIFF
--- a/app/islands/BookSearchForm.tsx
+++ b/app/islands/BookSearchForm.tsx
@@ -86,7 +86,7 @@ export default function BookSearchForm() {
       const data = await readApiResponse<BookDto>(res);
 
       if (data.success) {
-        window.location.href = `/books/${data.data.id}`;
+        window.location.href = `/books/new/complete?id=${data.data.id}`;
       } else {
         alert(data.error?.message || "登録に失敗しました");
       }

--- a/app/routes/books/new/complete.tsx
+++ b/app/routes/books/new/complete.tsx
@@ -1,0 +1,50 @@
+import { createRoute } from "honox/factory";
+import { requirePageAuth, getSidebarExpanded } from "../../../lib/page-auth";
+import { Layout } from "../../../components/layout/Layout";
+
+export default createRoute(async (c) => {
+  const authResult = await requirePageAuth(c);
+  if (authResult instanceof Response) {
+    return authResult;
+  }
+  const user = authResult;
+  const sidebarExpanded = getSidebarExpanded(c);
+
+  return c.render(
+    <Layout user={user} title="登録完了" sidebarExpanded={sidebarExpanded}>
+      <div class="max-w-xl mx-auto">
+        <div class="bg-white rounded-2xl p-10 shadow-sm ring-1 ring-zinc-100 text-center space-y-6">
+          <div class="mx-auto flex items-center justify-center w-16 h-16 rounded-full bg-emerald-50">
+            <svg
+              aria-hidden="true"
+              class="w-8 h-8 text-emerald-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <title>登録完了</title>
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </div>
+
+          <div class="space-y-2">
+            <h1 class="text-2xl font-bold text-zinc-900 tracking-tight">書籍を登録しました</h1>
+            <p class="text-zinc-500">本棚から登録した本を確認できます。</p>
+          </div>
+
+          <a
+            href="/books"
+            class="inline-flex items-center justify-center px-6 py-3 text-sm font-bold text-white bg-zinc-900 rounded-full hover:bg-zinc-800 transition-all shadow-sm"
+          >
+            本棚へ戻る
+          </a>
+        </div>
+      </div>
+    </Layout>,
+  );
+});


### PR DESCRIPTION
## 概要

書籍登録後の導線を、書籍詳細ページへ直接遷移する形から、登録完了メッセージを表示する中間ページを挟んでから本棚へ手動遷移する形に変更する。

## やったこと / やってないこと

- 書籍登録完了ページ `/books/new/complete` を新規追加（「書籍を登録しました」メッセージ + 「本棚へ戻る」ボタン）
- `BookSearchForm` の登録成功時のリダイレクト先を `/books/:id` から `/books/new/complete?id=:id` に変更
- 完了ページから書籍詳細ページへの直接リンクは今回追加していない
- 新規の自動テストは追加していない（本プロジェクトはルーティング/UI層に自動テストを持たない慣習のため、型チェックと既存テストスイートでリグレッションがないことを確認）

## 動作確認

- [x] `pnpm run typecheck` が通ること
- [x] 既存の自動テストスイート（255件）が全て成功し、リグレッションがないこと
- [x] 未認証で `/books/new/complete` にアクセスすると `/login` へリダイレクトされること（既存の `/books/new` と同じ挙動）
- [ ] 実際にログインし、検索→登録→完了ページ表示→「本棚へ戻る」の一連の導線を確認する（要手動確認）